### PR TITLE
Two small patches to let gowaves build on 32 bit systems (#533)

### DIFF
--- a/pkg/consensus/blocks_validation.go
+++ b/pkg/consensus/blocks_validation.go
@@ -19,8 +19,8 @@ const (
 	// In milliseconds.
 	maxTimeDrift = 100
 
-	minimalEffectiveBalanceForGenerator1 = 1000000000000
-	minimalEffectiveBalanceForGenerator2 = 100000000000
+	minimalEffectiveBalanceForGenerator1 = uint64(1000000000000)
+	minimalEffectiveBalanceForGenerator2 = uint64(100000000000)
 )
 
 // Invalid blocks that are already in blockchain.

--- a/pkg/libs/serializer/serializer.go
+++ b/pkg/libs/serializer/serializer.go
@@ -46,10 +46,12 @@ func (a *Serializer) StringWithUInt16Len(s string) error {
 
 // StringWithUInt32Len writes to the buffer `buf` four bytes of the string's `s` length followed with the bytes of string itself.
 func (a *Serializer) StringWithUInt32Len(s string) error {
-	if len(s) > math.MaxUint32 {
-		return errors.Errorf("too long string, expected max %d, found %d", math.MaxUint32, len(s))
+	lenStrU32 := uint32(len(s))
+	maxU32 := uint32(math.MaxUint32)
+	if lenStrU32 > maxU32 {
+		return errors.Errorf("too long string, expected max %d, found %d", maxU32, lenStrU32)
 	}
-	err := a.Uint32(uint32(len(s)))
+	err := a.Uint32(lenStrU32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* specify uint64 for constants

* tag uint32s for 32 bit builds

* camelCase for variables