### PR TITLE
Newest asset info fix

### DIFF
--- a/pkg/state/assets.go
+++ b/pkg/state/assets.go
@@ -266,8 +266,8 @@ type assetInfoChange struct {
 	newHeight      uint64
 }
 
-func (a *assets) updateAssetInfo(assetID proto.AssetID, ch *assetInfoChange, blockID proto.BlockID, filter bool) error {
-	info, err := a.newestChangeableInfo(assetID, filter)
+func (a *assets) updateAssetInfo(asset crypto.Digest, ch *assetInfoChange, blockID proto.BlockID, filter bool) error {
+	info, err := a.newestChangeableInfo(asset, filter)
 	if err != nil {
 		return errors.Errorf("failed to get asset info: %v\n", err)
 	}
@@ -275,7 +275,7 @@ func (a *assets) updateAssetInfo(assetID proto.AssetID, ch *assetInfoChange, blo
 	info.description = ch.newDescription
 	info.lastNameDescChangeHeight = ch.newHeight
 	record := &assetHistoryRecord{assetChangeableInfo: *info}
-	return a.addNewRecord(assetID, record, blockID)
+	return a.addNewRecord(proto.AssetIDFromDigest(asset), record, blockID)
 }
 
 func (a *assets) newestLastUpdateHeight(assetID proto.AssetID, filter bool) (uint64, error) {
@@ -309,7 +309,8 @@ func (a *assets) newestConstInfo(assetID proto.AssetID) (*assetConstInfo, error)
 	return a.constInfo(assetID)
 }
 
-func (a *assets) newestChangeableInfo(assetID proto.AssetID, filter bool) (*assetChangeableInfo, error) {
+func (a *assets) newestChangeableInfo(asset crypto.Digest, filter bool) (*assetChangeableInfo, error) {
+	assetID := proto.AssetIDFromDigest(asset)
 	if info, ok := a.uncertainAssetInfo[assetID]; ok {
 		return &info.assetChangeableInfo, nil
 	}
@@ -344,7 +345,7 @@ func (a *assets) newestAssetInfo(assetID proto.AssetID, filter bool) (*assetInfo
 	if err != nil {
 		return nil, err
 	}
-	changeableInfo, err := a.newestChangeableInfo(assetID, filter)
+	changeableInfo, err := a.newestChangeableInfo(proto.ReconstructDigest(assetID, constInfo.tail), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/state/assets_test.go
+++ b/pkg/state/assets_test.go
@@ -137,7 +137,7 @@ func TestUpdateAssetInfo(t *testing.T) {
 
 	to.stor.addBlock(t, blockID1)
 	ch := &assetInfoChange{newName: "newName", newDescription: "newDescription", newHeight: 1}
-	err = to.assets.updateAssetInfo(id, ch, blockID1, true)
+	err = to.assets.updateAssetInfo(assetID, ch, blockID1, true)
 	assert.NoError(t, err, "failed to update asset info")
 
 	asset.name = ch.newName
@@ -182,7 +182,7 @@ func TestNewestLastUpdateHeight(t *testing.T) {
 
 	to.stor.addBlock(t, blockID1)
 	ch := &assetInfoChange{newName: "newName", newDescription: "newDescription", newHeight: 2}
-	err = to.assets.updateAssetInfo(id, ch, blockID1, true)
+	err = to.assets.updateAssetInfo(assetID, ch, blockID1, true)
 	assert.NoError(t, err, "failed to update asset info")
 
 	lastUpdateHeight, err = to.assets.newestLastUpdateHeight(id, true)

--- a/pkg/state/transaction_performer.go
+++ b/pkg/state/transaction_performer.go
@@ -355,7 +355,7 @@ func (tp *transactionPerformer) performUpdateAssetInfoWithProofs(transaction pro
 		newDescription: tx.Description,
 		newHeight:      blockHeight,
 	}
-	if err := tp.stor.assets.updateAssetInfo(proto.AssetIDFromDigest(tx.AssetID), ch, info.blockID, !info.initialisation); err != nil {
+	if err := tp.stor.assets.updateAssetInfo(tx.AssetID, ch, info.blockID, !info.initialisation); err != nil {
 		return errors.Wrap(err, "failed to update asset info")
 	}
 	return nil


### PR DESCRIPTION
Now 'assets.newestChangeableInfo' and 'assets.updateAssetInfo' methods accept 'crypto.Digest' instead of 'proto.AssetID'.
