### PR TITLE
Client data endpoints with tests

### DIFF
--- a/pkg/client/addresses.go
+++ b/pkg/client/addresses.go
@@ -319,3 +319,88 @@ func (a *Addresses) BalanceAfterConfirmations(
 
 	return out, response, nil
 }
+
+type AddressesData struct {
+	Key   string      `json:"key"`
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+// AddressesData returns all data entries for given address
+func (a *Addresses) AddressesData(
+	ctx context.Context, address proto.WavesAddress) (*[]AddressesData, *Response, error) {
+
+	url, err := joinUrl(a.options.BaseUrl, fmt.Sprintf("/addresses/data/%s", address.String()))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := new([]AddressesData)
+	response, err := doHttp(ctx, a.options, req, out)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return out, response, nil
+}
+
+// AddressesDataKey returns data entry for given address and key
+func (a *Addresses) AddressesDataKey(
+	ctx context.Context, address proto.WavesAddress, key string) (*AddressesData, *Response, error) {
+
+	url, err := joinUrl(a.options.BaseUrl, fmt.Sprintf("/addresses/data/%s/%s", address.String(), key))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := new(AddressesData)
+	response, err := doHttp(ctx, a.options, req, out)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return out, response, nil
+}
+
+type AddressesDataKeys struct {
+	Keys []string `json:"keys"`
+}
+
+// AddressesDataKeys returns data entry for given address and keys
+func (a *Addresses) AddressesDataKeys(
+	ctx context.Context, address proto.WavesAddress, keys *AddressesDataKeys) (*[]AddressesData, *Response, error) {
+
+	url, err := joinUrl(a.options.BaseUrl, fmt.Sprintf("/addresses/data/%s", address.String()))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b := new(bytes.Buffer)
+	err = json.NewEncoder(b).Encode(keys)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("POST", url.String(), b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := new([]AddressesData)
+	response, err := doHttp(ctx, a.options, req, out)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return out, response, nil
+}

--- a/pkg/client/addresses_test.go
+++ b/pkg/client/addresses_test.go
@@ -275,3 +275,79 @@ func TestAddresses_BalanceAfterConfirmations(t *testing.T) {
 	assert.EqualValues(t, 37983102983592, body.Balance)
 	assert.Equal(t, "https://testnode1.wavesnodes.com/addresses/balance/3NBVqYXrapgJP9atQccdBPAgJPwHDKkh6A8/1", resp.Request.URL.String())
 }
+
+var addressData = `
+[
+  {
+    "key": "test1",
+    "type": "integer",
+    "value": 950000
+  },
+  {
+    "key": "test2",
+    "type": "string",
+    "value": "fdsafdsasdfasd"
+  },
+  {
+    "key": "test3",
+    "type": "string",
+    "value": "Aqy7PRU"
+  }
+]`
+
+var addressDataKey = `
+{
+	"key": "test3",
+	"type": "string",
+	"value": "Aqy7PRU"
+}`
+
+func TestAddresses_Data(t *testing.T) {
+	address, _ := proto.NewAddressFromString("3N3Aq1GcHD8bZMGyVgyvaTHrBM7EySFtJ1H")
+	client, err := NewClient(Options{
+		BaseUrl: "https://testnode1.wavesnodes.com/",
+		Client:  NewMockHttpRequestFromString(addressData, 200),
+	})
+	require.NoError(t, err)
+	body, resp, err :=
+		client.Addresses.AddressesData(context.Background(), address)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, len(*body), 3)
+	bValue := *body
+	assert.Equal(t, bValue[1].Value, "fdsafdsasdfasd")
+}
+
+func TestAddresses_DataKey(t *testing.T) {
+	address, _ := proto.NewAddressFromString("3N3Aq1GcHD8bZMGyVgyvaTHrBM7EySFtJ1H")
+	client, err := NewClient(Options{
+		BaseUrl: "https://testnode1.wavesnodes.com/",
+		Client:  NewMockHttpRequestFromString(addressDataKey, 200),
+	})
+	require.NoError(t, err)
+	body, resp, err :=
+		client.Addresses.AddressesDataKey(context.Background(), address, "test3")
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, body.Value, "Aqy7PRU")
+}
+
+func TestAddresses_DataKeys(t *testing.T) {
+	address, _ := proto.NewAddressFromString("3N3Aq1GcHD8bZMGyVgyvaTHrBM7EySFtJ1H")
+	client, err := NewClient(Options{
+		BaseUrl: "https://testnode1.wavesnodes.com/",
+		Client:  NewMockHttpRequestFromString(addressData, 200),
+	})
+	require.NoError(t, err)
+
+	keys := &AddressesDataKeys{}
+	keys.Keys = append(keys.Keys, "test1", "test2", "test3")
+
+	body, resp, err :=
+		client.Addresses.AddressesDataKeys(context.Background(), address, keys)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, len(*body), 3)
+	bValue := *body
+	assert.Equal(t, bValue[1].Value, "fdsafdsasdfasd")
+}


### PR DESCRIPTION
New API endpoints in client (with tests):

/addresses/data/{address} (GET - AddressesData)
/addresses/data/{address}/{key} (GET- AddressesDataKey)
/addresses/data/{address} (POST - AddressesDataKeys)