### PR TITLE
Mainnet -> testnet in tests

### DIFF
--- a/cmd/retransmitter/retransmit/behaviour_test.go
+++ b/cmd/retransmitter/retransmit/behaviour_test.go
@@ -18,7 +18,7 @@ import (
 func TestClientRecvTransaction(t *testing.T) {
 	knownPeers, _ := utils.NewKnownPeers(utils.NoOnStorage{})
 
-	behaviour := retransmit.NewBehaviour(knownPeers, nil, proto.MainNetScheme)
+	behaviour := retransmit.NewBehaviour(knownPeers, nil, proto.TestNetScheme)
 
 	peer1 := &mock.Peer{
 		Addr:          "peer1",

--- a/cmd/retransmitter/retransmit/transaction_list_test.go
+++ b/cmd/retransmitter/retransmit/transaction_list_test.go
@@ -1,10 +1,11 @@
 package retransmit
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/proto"
-	"testing"
 )
 
 func TestTransactionList(t *testing.T) {
@@ -13,7 +14,7 @@ func TestTransactionList(t *testing.T) {
 	d3, _ := crypto.FastHash([]byte("3"))
 	d4, _ := crypto.FastHash([]byte("4"))
 
-	lst := NewTransactionList(2, proto.MainNetScheme)
+	lst := NewTransactionList(2, proto.TestNetScheme)
 	assert.Equal(t, 0, lst.Len())
 
 	t1 := proto.TransferWithProofs{ID: &d1}

--- a/pkg/grpc/server/common_test.go
+++ b/pkg/grpc/server/common_test.go
@@ -72,9 +72,9 @@ func customSettingsWithGenesis(t *testing.T, genesisPath string) *settings.Block
 	sets := settings.DefaultCustomSettings
 	signBlock(t, genesis, sets.AddressSchemeCharacter)
 	sets.Genesis = *genesis
-	// For compatibility with MainNet addresses we use the same AddressSchemeCharacter.
-	// This is needed because transactions from MainNet blockchain are used in tests' genesis blocks.
-	sets.AddressSchemeCharacter = settings.MainNetSettings.AddressSchemeCharacter
+	// For compatibility with TestNet addresses we use the same AddressSchemeCharacter.
+	// This is needed because transactions from TestNet blockchain are used in tests' genesis blocks.
+	sets.AddressSchemeCharacter = settings.TestNetSettings.AddressSchemeCharacter
 	sets.BlockRewardTerm = 100000
 	return sets
 }
@@ -100,7 +100,7 @@ func createWallet(ctx context.Context, st state.State, settings *settings.Blockc
 	w := wallet.NewWallet()
 	decoded, _ := base58.Decode(seed)
 	_ = w.AddSeed(decoded)
-	return wallet.NewEmbeddedWallet(nil, w, proto.MainNetScheme)
+	return wallet.NewEmbeddedWallet(nil, w, proto.TestNetScheme)
 }
 
 func connect(t *testing.T, addr string) *grpc.ClientConn {

--- a/pkg/miner/internal_test.go
+++ b/pkg/miner/internal_test.go
@@ -18,7 +18,7 @@ func TestMineBlock(t *testing.T) {
 	require.NoError(t, err)
 	parentSig := crypto.MustSignatureFromBase58("4f6Nkihj7j3t2ohNPk69MUZzpdHHwXG9hM2qjgeRmKmDPFiRYeedv6ewc9dhvNo1BxvE5CTgTjTTyAYPfR42eBXP")
 	parent := proto.NewBlockIDFromSignature(parentSig)
-	b, err := MineBlock(4, nxt, kp, []settings.Feature{13, 14}, 1581610238465, parent, 600000000, proto.MainNetScheme)
+	b, err := MineBlock(4, nxt, kp, []settings.Feature{13, 14}, 1581610238465, parent, 600000000, proto.TestNetScheme)
 	require.NoError(t, err)
 
 	bts, err := b.MarshalBinary()

--- a/pkg/miner/miner_test.go
+++ b/pkg/miner/miner_test.go
@@ -34,12 +34,12 @@ func TestMineMicroblock(t *testing.T) {
 		proto.TestNetScheme,
 	)
 	require.NoError(t, err)
-	err = keyBlock.Sign(proto.MainNetScheme, keyPair.Secret)
+	err = keyBlock.Sign(proto.TestNetScheme, keyPair.Secret)
 	require.NoError(t, err)
 
 	transferWithSig := byte_helpers.TransferWithSig.Transaction.Clone()
 
-	_, err = createMicroBlock(keyBlock, []proto.Transaction{transferWithSig}, keyPair, proto.MainNetScheme)
+	_, err = createMicroBlock(keyBlock, []proto.Transaction{transferWithSig}, keyPair, proto.TestNetScheme)
 	require.NoError(t, err)
 }
 
@@ -63,7 +63,7 @@ func createMicroBlock(keyBlock *proto.Block, tr proto.Transactions, keyPair prot
 	}
 
 	sk := keyPair.Secret
-	err = newBlock.Sign(proto.MainNetScheme, keyPair.Secret)
+	err = newBlock.Sign(proto.TestNetScheme, keyPair.Secret)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func createMicroBlock(keyBlock *proto.Block, tr proto.Transactions, keyPair prot
 		TotalResBlockSigField: newBlock.BlockSignature,
 	}
 
-	err = micro.Sign(proto.MainNetScheme, sk)
+	err = micro.Sign(proto.TestNetScheme, sk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proto/addresses_test.go
+++ b/pkg/proto/addresses_test.go
@@ -101,7 +101,7 @@ func BenchmarkNewWavesAddressFromPublicKey(b *testing.B) {
 		b.Fatalf("crypto.GenerateKeyPair(): %v", err)
 	}
 	for n := 0; n < b.N; n++ {
-		_, _ = NewAddressFromPublicKey(MainNetScheme, pk)
+		_, _ = NewAddressFromPublicKey(TestNetScheme, pk)
 	}
 }
 
@@ -126,7 +126,7 @@ func TestAliasFromString(t *testing.T) {
 func TestIncorrectAlias(t *testing.T) {
 	aliases := []string{"xxx", "xxxl-very-very-very-long-alias-that-is-incorrect", "asd=asd", "QazWsxEdc"}
 	for _, alias := range aliases {
-		a := NewAlias(MainNetScheme, alias)
+		a := NewAlias(TestNetScheme, alias)
 		v, err := a.Valid()
 		assert.False(t, v)
 		assert.Error(t, err)

--- a/pkg/proto/microblock_test.go
+++ b/pkg/proto/microblock_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMicroBlock_Marshaling(t *testing.T) {
 	txBytes := []byte{0, 0, 0, 152, 4, 76, 252, 177, 12, 123, 169, 56, 92, 8, 85, 82, 118, 1, 166, 228, 57, 52, 84, 161, 19, 144, 247, 9, 93, 114, 88, 198, 123, 123, 210, 188, 95, 177, 170, 229, 15, 176, 248, 128, 112, 121, 201, 53, 221, 15, 55, 231, 118, 113, 192, 201, 113, 251, 55, 6, 95, 207, 47, 24, 71, 240, 162, 206, 6, 4, 236, 89, 77, 54, 8, 236, 240, 30, 10, 87, 121, 139, 23, 7, 114, 121, 45, 177, 69, 50, 132, 55, 119, 224, 172, 245, 68, 95, 44, 28, 243, 4, 0, 0, 0, 0, 1, 107, 137, 11, 41, 201, 0, 0, 0, 10, 247, 96, 247, 0, 0, 0, 0, 0, 0, 1, 134, 160, 1, 87, 126, 90, 125, 49, 243, 210, 18, 83, 195, 130, 223, 30, 209, 178, 95, 17, 186, 108, 63, 172, 209, 224, 228, 138, 0, 0}
-	txs, err := NewTransactionsFromBytes(txBytes, 1, MainNetScheme)
+	txs, err := NewTransactionsFromBytes(txBytes, 1, TestNetScheme)
 	require.NoError(t, err)
 	refSig := crypto.MustSignatureFromBase58("37ex9gonRZtUddDHgSzSes5Ds9UeQyS74DyAXtGFrDpJnEg7sjGdi2ncaV4rVpZnLboQmid3whcbZUWS49FV3ZCs")
 	ref := NewBlockIDFromSignature(refSig)
@@ -27,14 +27,14 @@ func TestMicroBlock_Marshaling(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	_, _ = m.WriteTo(MainNetScheme, buf)
+	_, _ = m.WriteTo(TestNetScheme, buf)
 
 	m2 := MicroBlock{}
-	_ = m2.UnmarshalBinary(buf.Bytes(), MainNetScheme)
+	_ = m2.UnmarshalBinary(buf.Bytes(), TestNetScheme)
 
 	require.Equal(t, m, m2)
 
-	rs, err := m.VerifySignature(MainNetScheme)
+	rs, err := m.VerifySignature(TestNetScheme)
 	require.NoError(t, err)
 	require.True(t, rs)
 }
@@ -92,8 +92,8 @@ func TestMicroBlockInv_SignVerify(t *testing.T) {
 		Reference:    ref,
 	}
 
-	require.NoError(t, c1.Sign(sec, MainNetScheme))
-	rs, err := c1.Verify(MainNetScheme)
+	require.NoError(t, c1.Sign(sec, TestNetScheme))
+	rs, err := c1.Verify(TestNetScheme)
 	require.NoError(t, err)
 	require.True(t, rs)
 }

--- a/pkg/proto/transactions_test.go
+++ b/pkg/proto/transactions_test.go
@@ -62,9 +62,9 @@ func TestGenesisBinarySize(t *testing.T) {
 	for _, tc := range tests {
 		if rcp, err := NewAddressFromString(tc.recipient); assert.NoError(t, err) {
 			tx := NewUnsignedGenesis(rcp, tc.amount, tc.timestamp)
-			err = tx.Sign(MainNetScheme, sk)
+			err = tx.Sign(TestNetScheme, sk)
 			assert.Nil(t, err)
-			_, err := tx.Validate(MainNetScheme)
+			_, err := tx.Validate(TestNetScheme)
 			assert.Nil(t, err)
 			txBytes, err := tx.MarshalBinary()
 			assert.Nil(t, err)
@@ -91,9 +91,9 @@ func TestGenesisFromMainNet(t *testing.T) {
 		id, _ := base58.Decode(tc.sig)
 		if rcp, err := NewAddressFromString(tc.recipient); assert.NoError(t, err) {
 			tx := NewUnsignedGenesis(rcp, tc.amount, tc.timestamp)
-			_, err := tx.Validate(MainNetScheme)
+			_, err := tx.Validate(TestNetScheme)
 			assert.Nil(t, err)
-			if err := tx.GenerateSigID(MainNetScheme); assert.NoError(t, err) {
+			if err := tx.GenerateSigID(TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, id, tx.ID[:])
 				assert.Equal(t, tc.amount, tx.Amount)
 				assert.Equal(t, tc.recipient, tx.Recipient.String())
@@ -101,9 +101,9 @@ func TestGenesisFromMainNet(t *testing.T) {
 				b, err := tx.MarshalBinary()
 				assert.NoError(t, err)
 				var at Genesis
-				err = at.UnmarshalBinary(b, MainNetScheme)
+				err = at.UnmarshalBinary(b, TestNetScheme)
 				assert.NoError(t, err)
-				err = at.GenerateID(MainNetScheme)
+				err = at.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, at)
 			}
@@ -169,7 +169,7 @@ func TestGenesisValidations(t *testing.T) {
 		require.NoError(t, err)
 		tx := NewUnsignedGenesis(addr, tc.amount, 0)
 		assert.NotNil(t, tx)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -179,7 +179,7 @@ func TestGenesisToJSON(t *testing.T) {
 	if rcp, err := NewAddressFromString(addr); assert.NoError(t, err) {
 		ts := uint64(time.Now().Unix() * 1000)
 		tx := NewUnsignedGenesis(rcp, 1000, ts)
-		err := tx.GenerateSigID(MainNetScheme)
+		err := tx.GenerateSigID(TestNetScheme)
 		require.NoError(t, err)
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":1,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"timestamp\":%d,\"recipient\":\"%s\",\"amount\":1000}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), ts, tx.Recipient.String())
@@ -203,7 +203,7 @@ func TestPaymentBinarySize(t *testing.T) {
 		addr, err := addressFromString(tc.address)
 		require.NoError(t, err)
 		tx := NewUnsignedPayment(pk, addr, tc.amount, tc.fee, 1)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		require.NoError(t, err)
@@ -226,14 +226,14 @@ func TestPaymentMarshalUnmarshal(t *testing.T) {
 		addr, err := addressFromString(tc.address)
 		require.NoError(t, err)
 		tx := NewUnsignedPayment(pk, addr, tc.amount, tc.fee, 1)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
 		var tx1 Payment
-		err = tx1.UnmarshalBinary(txBytes, MainNetScheme)
+		err = tx1.UnmarshalBinary(txBytes, TestNetScheme)
 		require.NoError(t, err)
-		err = tx1.GenerateID(MainNetScheme)
+		err = tx1.GenerateID(TestNetScheme)
 		assert.NoError(t, err)
 		assert.Equal(t, *tx, tx1)
 	}
@@ -309,13 +309,13 @@ func TestPaymentFromMainNet(t *testing.T) {
 			assert.Equal(t, *tx, at)
 			tx.Signature = &sig
 			tx.ID = &sig
-			vr, err := tx.Verify(MainNetScheme, spk)
+			vr, err := tx.Verify(TestNetScheme, spk)
 			require.NoError(t, err)
 			assert.True(t, vr)
 			b, _ = tx.MarshalBinary()
-			err = at.UnmarshalBinary(b, MainNetScheme)
+			err = at.UnmarshalBinary(b, TestNetScheme)
 			assert.NoError(t, err)
-			err = at.GenerateID(MainNetScheme)
+			err = at.GenerateID(TestNetScheme)
 			assert.NoError(t, err)
 			assert.Equal(t, *tx, at)
 
@@ -373,7 +373,7 @@ func TestPaymentValidations(t *testing.T) {
 		addr, err := addressFromString(tc.address)
 		require.NoError(t, err)
 		tx := NewUnsignedPayment(spk, addr, tc.amount, tc.fee, 0)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -385,7 +385,7 @@ func TestPaymentToJSON(t *testing.T) {
 	rcp, _ := NewAddressFromString("3PAWwWa6GbwcJaFzwqXQN5KQm7H96Y7SHTQ")
 	ts := uint64(time.Now().Unix() * 1000)
 	tx := NewUnsignedPayment(pk, rcp, 1000, 10, ts)
-	err = tx.Sign(MainNetScheme, sk)
+	err = tx.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	if j, err := json.Marshal(tx); assert.NoError(t, err) {
 		ej := fmt.Sprintf("{\"type\":2,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"recipient\":\"%s\",\"amount\":1000,\"fee\":10,\"timestamp\":%d}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(tx.SenderPK[:]), tx.Recipient.String(), ts)
@@ -442,7 +442,7 @@ func TestIssueWithSigValidations(t *testing.T) {
 		spk, err := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		if assert.NoError(t, err) {
 			tx := NewUnsignedIssueWithSig(spk, tc.name, tc.desc, tc.quantity, tc.decimals, false, 0, tc.fee)
-			_, err := tx.Validate(MainNetScheme)
+			_, err := tx.Validate(TestNetScheme)
 			assert.EqualError(t, err, tc.err)
 		}
 	}
@@ -456,7 +456,7 @@ func TestIssueWithSigBinarySize(t *testing.T) {
 		assert.NoError(t, err)
 		ts := uint64(time.Now().Unix() * 1000)
 		tx := NewUnsignedIssueWithSig(pk, "TOKEN", "description", 1000, 10, false, ts, 100000)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -472,9 +472,9 @@ func TestIssueWithSigSigningRoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 		ts := uint64(time.Now().Unix() * 1000)
 		tx := NewUnsignedIssueWithSig(pk, "TOKEN", "", 1000, 0, false, ts, 100000)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		if assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
@@ -490,7 +490,7 @@ func TestIssueWithSigToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":3,\"version\":1,\"senderPublicKey\":\"%s\",\"name\":\"TOKEN\",\"description\":\"\",\"quantity\":1000,\"decimals\":0,\"reissuable\":false,\"timestamp\":%d,\"fee\":100000}", base58.Encode(pk[:]), ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":3,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"name\":\"TOKEN\",\"description\":\"\",\"quantity\":1000,\"decimals\":0,\"reissuable\":false,\"timestamp\":%d,\"fee\":100000}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), ts)
 					assert.Equal(t, esj, string(sj))
@@ -534,13 +534,13 @@ func TestIssueWithSigBinaryRoundTrip(t *testing.T) {
 			assert.Equal(t, tc.ts, at.Timestamp)
 			assert.Equal(t, tc.fee, at.Fee)
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 			if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 				var at IssueWithSig
-				if err = at.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
-					err = at.GenerateID(MainNetScheme)
+				if err = at.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
+					err = at.GenerateID(TestNetScheme)
 					assert.NoError(t, err)
-					err = at.GenerateID(MainNetScheme)
+					err = at.GenerateID(TestNetScheme)
 					assert.NoError(t, err)
 					assert.Equal(t, *tx, at)
 					assert.Equal(t, pk, at.SenderPK)
@@ -577,19 +577,19 @@ func TestIssueWithSigProtobufRoundTrip(t *testing.T) {
 	}
 	for _, tc := range tests {
 		tx := NewUnsignedIssueWithSig(pk, tc.name, tc.desc, tc.quantity, tc.decimals, tc.reissuable, tc.ts, tc.fee)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		assert.NoError(t, err)
-		b, err := tx.MarshalToProtobuf(MainNetScheme)
+		b, err := tx.MarshalToProtobuf(TestNetScheme)
 		assert.NoError(t, err)
 		var at IssueWithSig
 		if err := at.UnmarshalFromProtobuf(b); assert.NoError(t, err) {
 			assert.Equal(t, *tx, at)
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 				var at IssueWithSig
 				if err = at.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-					err = at.GenerateID(MainNetScheme)
+					err = at.GenerateID(TestNetScheme)
 					assert.NoError(t, err)
 					assert.Equal(t, *tx, at)
 				}
@@ -620,7 +620,7 @@ func TestIssueWithProofsValidations(t *testing.T) {
 	for _, tc := range tests {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		tx := NewUnsignedIssueWithProofs(2, 'T', spk, tc.name, tc.desc, tc.quantity, tc.decimals, false, []byte{}, 0, tc.fee)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -855,7 +855,7 @@ func TestTransferWithSigValidations(t *testing.T) {
 		require.NoError(t, err)
 		att := []byte(tc.att)
 		tx := NewUnsignedTransferWithSig(spk, *a, *a, 0, tc.amount, tc.fee, rcp, att)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err, "No expected error '%s'", tc.err)
 	}
 }
@@ -1080,7 +1080,7 @@ func TestTransferWithSigFromMainNet(t *testing.T) {
 		require.NoError(t, err)
 		h, _ := crypto.FastHash(b)
 		assert.Equal(t, *tx.ID, h)
-		if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 			assert.True(t, r)
 		}
 	}
@@ -1117,7 +1117,7 @@ func TestTransferWithSigToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"type\":4,\"version\":1,\"senderPublicKey\":\"%s\",\"assetId\":%s,\"feeAssetId\":%s,\"timestamp\":%d,\"amount\":100000000,\"fee\":100000,\"recipient\":\"3PDgLyMzNLkHF2cV1y7NhpmyS2HQjd57SWu\"%s}", base58.Encode(pk[:]), tc.expectedAmountAsset, tc.expectedFeeAsset, ts, tc.expectedAttachment)
 			assert.Equal(t, ej, string(j))
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 			if j, err := json.Marshal(tx); assert.NoError(t, err) {
 				ej := fmt.Sprintf("{\"type\":4,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"assetId\":%s,\"feeAssetId\":%s,\"timestamp\":%d,\"amount\":100000000,\"fee\":100000,\"recipient\":\"3PDgLyMzNLkHF2cV1y7NhpmyS2HQjd57SWu\"%s}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), tc.expectedAmountAsset, tc.expectedFeeAsset, ts, tc.expectedAttachment)
 				assert.Equal(t, ej, string(j))
@@ -1151,7 +1151,7 @@ func TestTransferWithProofsValidations(t *testing.T) {
 		require.NoError(t, err)
 		att := []byte(tc.att)
 		tx := NewUnsignedTransferWithProofs(2, spk, *a, *a, 0, tc.amount, tc.fee, rcp, att)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err, "No expected error '%s'", tc.err)
 	}
 }
@@ -1499,7 +1499,7 @@ func TestTransferWithProofsToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"type\":4,\"version\":2,\"senderPublicKey\":\"%s\",\"assetId\":%s,\"feeAssetId\":%s,\"timestamp\":%d,\"amount\":100000000,\"fee\":100000,\"recipient\":\"3PDgLyMzNLkHF2cV1y7NhpmyS2HQjd57SWu\"%s}", base58.Encode(pk[:]), tc.expectedAmountAsset, tc.expectedFeeAsset, ts, tc.expectedAttachment)
 			assert.Equal(t, ej, string(j))
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 			if j, err := json.Marshal(tx); assert.NoError(t, err) {
 				ej := fmt.Sprintf("{\"type\":4,\"version\":2,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"assetId\":%s,\"feeAssetId\":%s,\"timestamp\":%d,\"amount\":100000000,\"fee\":100000,\"recipient\":\"3PDgLyMzNLkHF2cV1y7NhpmyS2HQjd57SWu\"%s}",
 					base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(pk[:]), tc.expectedAmountAsset, tc.expectedFeeAsset, ts, tc.expectedAttachment)
@@ -1547,7 +1547,7 @@ func TestReissueWithSigValidations(t *testing.T) {
 		aid, err := crypto.NewDigestFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		require.NoError(t, err)
 		tx := NewUnsignedReissueWithSig(spk, aid, tc.quantity, false, 0, tc.fee)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -1601,23 +1601,23 @@ func TestReissueWithSigProtobufRoundTrip(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedReissueWithSig(pk, aid, tc.quantity, tc.reissuable, ts, tc.fee)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ReissueWithSig
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ReissueWithSig
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -1642,7 +1642,7 @@ func TestReissueWithSigBinarySize(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedReissueWithSig(pk, aid, tc.quantity, tc.reissuable, ts, tc.fee)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -1680,14 +1680,14 @@ func TestReissueWithSigBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx ReissueWithSig
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.ElementsMatch(t, *tx.Signature, *atx.Signature)
 				assert.ElementsMatch(t, pk, atx.SenderPK)
 				assert.ElementsMatch(t, aid, atx.AssetID)
@@ -1721,7 +1721,7 @@ func TestReissueWithSigToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":5,\"version\":1,\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"quantity\":%d,\"reissuable\":%v,\"timestamp\":%d,\"fee\":%d}", base58.Encode(pk[:]), tc.asset, tc.quantity, tc.reissuable, ts, tc.fee)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":5,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"quantity\":%d,\"reissuable\":%v,\"timestamp\":%d,\"fee\":%d}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), tc.asset, tc.quantity, tc.reissuable, ts, tc.fee)
 					assert.Equal(t, esj, string(sj))
@@ -1747,7 +1747,7 @@ func TestReissueWithProofsValidations(t *testing.T) {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		aid, _ := crypto.NewDigestFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		tx := NewUnsignedReissueWithProofs(2, 'T', spk, aid, tc.quantity, false, 0, tc.fee)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -1955,7 +1955,7 @@ func TestBurnWithSigValidations(t *testing.T) {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		aid, _ := crypto.NewDigestFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		tx := NewUnsignedBurnWithSig(spk, aid, tc.amount, 0, tc.fee)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -2007,23 +2007,23 @@ func TestBurnWithSigProtobufRoundTrip(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedBurnWithSig(pk, aid, tc.amount, ts, tc.fee)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx BurnWithSig
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx BurnWithSig
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -2047,7 +2047,7 @@ func TestBurnWithSigBinarySize(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedBurnWithSig(pk, aid, tc.amount, ts, tc.fee)
-		err := tx.Sign(MainNetScheme, sk)
+		err := tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -2071,14 +2071,14 @@ func TestBurnWithSigBinaryRoundTrip(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedBurnWithSig(pk, aid, tc.amount, ts, tc.fee)
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx BurnWithSig
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, tx.Signature, atx.Signature)
 				assert.Equal(t, pk, atx.SenderPK)
 				assert.Equal(t, aid, atx.AssetID)
@@ -2109,7 +2109,7 @@ func TestBurnWithSigToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":6,\"version\":1,\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"amount\":%d,\"timestamp\":%d,\"fee\":%d}", base58.Encode(pk[:]), tc.asset, tc.amount, ts, tc.fee)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":6,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"amount\":%d,\"timestamp\":%d,\"fee\":%d}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), tc.asset, tc.amount, ts, tc.fee)
 					assert.Equal(t, esj, string(sj))
@@ -2226,7 +2226,7 @@ func TestBurnWithProofsBinarySize(t *testing.T) {
 		aid, _ := crypto.NewDigestFromBase58(tc.asset)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedBurnWithProofs(2, 'T', pk, aid, tc.amount, ts, tc.fee)
-		err := tx.Sign(MainNetScheme, sk)
+		err := tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		require.NoError(t, err)
@@ -2362,7 +2362,7 @@ func TestExchangeWithSigValidations(t *testing.T) {
 	}
 	for _, tc := range tests {
 		tx := NewUnsignedExchangeWithSig(&tc.buy, &tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, tc.ts)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.Error(t, err)
 		assert.Regexp(t, tc.err, err.Error(), fmt.Sprintf("expected: %s", tc.err))
 	}
@@ -2496,10 +2496,10 @@ func TestExchangeWithSigProtobufRoundTrip(t *testing.T) {
 	ts := NewTimestampFromTime(time.Now())
 	exp := ts + 100*1000
 	bo := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 98765, 67890, ts, exp, 3)
-	err = bo.Sign(MainNetScheme, sk)
+	err = bo.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so.Sign(MainNetScheme, sk)
+	err = so.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     OrderV1
@@ -2515,23 +2515,23 @@ func TestExchangeWithSigProtobufRoundTrip(t *testing.T) {
 	for _, tc := range tests {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedExchangeWithSig(&tc.buy, &tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ExchangeWithSig
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, mpk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, mpk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ExchangeWithSig
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -2551,10 +2551,10 @@ func TestExchangeWithSigBinarySize(t *testing.T) {
 	ts := uint64(time.Now().UnixNano() / 1000000)
 	exp := ts + 100*1000
 	bo := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo.Sign(MainNetScheme, sk)
+	err = bo.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so.Sign(MainNetScheme, sk)
+	err = so.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     OrderV1
@@ -2571,7 +2571,7 @@ func TestExchangeWithSigBinarySize(t *testing.T) {
 	for _, tc := range tests {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedExchangeWithSig(&tc.buy, &tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, msk)
+		err = tx.Sign(TestNetScheme, msk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -2591,10 +2591,10 @@ func TestExchangeWithSigBinaryRoundTrip(t *testing.T) {
 	ts := uint64(time.Now().UnixNano() / 1000000)
 	exp := ts + 100*1000
 	bo := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo.Sign(MainNetScheme, sk)
+	err = bo.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so.Sign(MainNetScheme, sk)
+	err = so.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     OrderV1
@@ -2627,14 +2627,14 @@ func TestExchangeWithSigBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, mpk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, mpk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx ExchangeWithSig
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, tx.Type, atx.Type)
 				assert.Equal(t, tx.Version, atx.Version)
 				assert.Equal(t, tx.Signature, atx.Signature)
@@ -2682,11 +2682,11 @@ func TestExchangeWithSigToJSON(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		bo := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, tc.buyPrice, tc.buyAmount, ts, exp, tc.fee)
-		err := bo.Sign(MainNetScheme, sk)
+		err := bo.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		boj, _ := json.Marshal(bo)
 		so := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, tc.sellPrice, tc.sellAmount, ts, exp, tc.fee)
-		err = so.Sign(MainNetScheme, sk)
+		err = so.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		soj, _ := json.Marshal(so)
 		tx := NewUnsignedExchangeWithSig(bo, so, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
@@ -2694,7 +2694,7 @@ func TestExchangeWithSigToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"type\":7,\"version\":1,\"senderPublicKey\":\"%s\",\"order1\":%s,\"order2\":%s,\"price\":%d,\"amount\":%d,\"buyMatcherFee\":%d,\"sellMatcherFee\":%d,\"fee\":%d,\"timestamp\":%d}",
 				base58.Encode(mpk[:]), string(boj), string(soj), tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
 				if j, err := json.Marshal(tx); assert.NoError(t, err) {
 					ej := fmt.Sprintf("{\"type\":7,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"order1\":%s,\"order2\":%s,\"price\":%d,\"amount\":%d,\"buyMatcherFee\":%d,\"sellMatcherFee\":%d,\"fee\":%d,\"timestamp\":%d}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(mpk[:]), string(boj), string(soj), tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
@@ -2754,7 +2754,7 @@ func TestExchangeWithProofsValidations(t *testing.T) {
 	}
 	for _, tc := range tests {
 		tx := NewUnsignedExchangeWithProofs(2, &tc.buy, &tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, tc.ts)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.Error(t, err)
 		assert.Regexp(t, tc.err, err, fmt.Sprintf("expected error: %s", tc.err))
 	}
@@ -2769,7 +2769,7 @@ func TestExchangeV3PriceValidation(t *testing.T) {
 	sbo := newSignedOrderV4(t, buySender, mpk, *aa, *pa, Buy, 1000000, 800000000, 1624445095222, 1626950695222, 300000, "3fdNTCQ7o2TvN8eDV3m7J9aSLxcUitwN2SMZpn1irSXX", "3aKUz8boZingH8r18grL8Rst5RyGVnESaQtuEoV5piUnvJKNf67xFwFpPpmfiuAuud1AAzj94xYNw1MKkmJaBicR", OrderPriceModeDefault)
 	sso := newSignedOrderV4(t, sellSender, mpk, *aa, *pa, Sell, 1000000, 800000000, 1624445095267, 1626950695267, 300000, "81Xc8YP1Ev2bqvSLgN5k3ent6Fr7rnEdCg8x2DH5twqX", "4VQmM6QB8yaQ1AChNNkVH5EvVKenS8YG7YqXK9SsjWAnjJm5xvd48kW2akwcEbhgzqqGMDtS2AmeGSfpEcHEMYGU", OrderPriceModeDefault)
 	tx := NewUnsignedExchangeWithProofs(3, &sbo, &sso, 100000000, 800000000, 100, 100, 300000, 1624445095293)
-	_, err := tx.Validate(MainNetScheme)
+	_, err := tx.Validate(TestNetScheme)
 	assert.NoError(t, err)
 }
 
@@ -2848,16 +2848,16 @@ func TestExchangeWithProofsProtobufRoundTrip(t *testing.T) {
 	ts := NewTimestampFromTime(time.Now())
 	exp := ts + 100*1000
 	bo1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo1.Sign(MainNetScheme, sk)
+	err = bo1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 12345, 54321, ts, exp, 3)
-	err = so1.Sign(MainNetScheme, sk)
+	err = so1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	bo2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo2.Sign(MainNetScheme, sk)
+	err = bo2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Sell, 12345, 54321, ts, exp, 3)
-	err = so2.Sign(MainNetScheme, sk)
+	err = so2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     Order
@@ -2880,23 +2880,23 @@ func TestExchangeWithProofsProtobufRoundTrip(t *testing.T) {
 	for _, tc := range tests {
 		ts := NewTimestampFromTime(time.Now())
 		tx := NewUnsignedExchangeWithProofs(2, tc.buy, tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ExchangeWithProofs
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, mpk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, mpk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx ExchangeWithProofs
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -2916,16 +2916,16 @@ func TestExchangeWithProofsBinarySize(t *testing.T) {
 	ts := uint64(time.Now().UnixNano() / 1000000)
 	exp := ts + 100*1000
 	bo1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo1.Sign(MainNetScheme, sk)
+	err = bo1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so1.Sign(MainNetScheme, sk)
+	err = so1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	bo2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo2.Sign(MainNetScheme, sk)
+	err = bo2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so2.Sign(MainNetScheme, sk)
+	err = so2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     Order
@@ -2944,7 +2944,7 @@ func TestExchangeWithProofsBinarySize(t *testing.T) {
 	for _, tc := range tests {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedExchangeWithProofs(2, tc.buy, tc.sell, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, msk)
+		err = tx.Sign(TestNetScheme, msk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -2964,16 +2964,16 @@ func TestExchangeWithProofsBinaryRoundTrip(t *testing.T) {
 	ts := uint64(time.Now().UnixNano() / 1000000)
 	exp := ts + 100*1000
 	bo1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo1.Sign(MainNetScheme, sk)
+	err = bo1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so1 := NewUnsignedOrderV1(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so1.Sign(MainNetScheme, sk)
+	err = so1.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	bo2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Buy, 12345, 67890, ts, exp, 3)
-	err = bo2.Sign(MainNetScheme, sk)
+	err = bo2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	so2 := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Sell, 98765, 54321, ts, exp, 3)
-	err = so2.Sign(MainNetScheme, sk)
+	err = so2.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 	tests := []struct {
 		buy     Order
@@ -3008,14 +3008,14 @@ func TestExchangeWithProofsBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, mpk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, mpk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx ExchangeWithProofs
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, tx.Type, atx.Type)
 				assert.Equal(t, tx.Version, atx.Version)
 				assert.ElementsMatch(t, tx.Proofs.Proofs[0], atx.Proofs.Proofs[0])
@@ -3063,11 +3063,11 @@ func TestExchangeWithProofsToJSON(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		bo := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Buy, tc.buyPrice, tc.buyAmount, ts, exp, tc.fee)
-		err := bo.Sign(MainNetScheme, sk)
+		err := bo.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		boj, _ := json.Marshal(bo)
 		so := NewUnsignedOrderV2(pk, mpk, *aa, *pa, Sell, tc.sellPrice, tc.sellAmount, ts, exp, tc.fee)
-		err = so.Sign(MainNetScheme, sk)
+		err = so.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 		soj, _ := json.Marshal(so)
 		tx := NewUnsignedExchangeWithProofs(2, bo, so, tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
@@ -3075,7 +3075,7 @@ func TestExchangeWithProofsToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"type\":7,\"version\":2,\"senderPublicKey\":\"%s\",\"order1\":%s,\"order2\":%s,\"price\":%d,\"amount\":%d,\"buyMatcherFee\":%d,\"sellMatcherFee\":%d,\"fee\":%d,\"timestamp\":%d}",
 				base58.Encode(mpk[:]), string(boj), string(soj), tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, msk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, msk); assert.NoError(t, err) {
 				if j, err := json.Marshal(tx); assert.NoError(t, err) {
 					ej := fmt.Sprintf("{\"type\":7,\"version\":2,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"order1\":%s,\"order2\":%s,\"price\":%d,\"amount\":%d,\"buyMatcherFee\":%d,\"sellMatcherFee\":%d,\"fee\":%d,\"timestamp\":%d}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(mpk[:]), string(boj), string(soj), tc.price, tc.amount, tc.buyFee, tc.sellFee, tc.fee, ts)
@@ -3590,7 +3590,7 @@ func TestLeaseWithSigValidations(t *testing.T) {
 		rcp, err := recipientFromString(tc.recipient)
 		require.NoError(t, err)
 		tx := NewUnsignedLeaseWithSig(spk, rcp, tc.amount, tc.fee, 0)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -3687,7 +3687,7 @@ func TestLeaseWithSigBinarySize(t *testing.T) {
 		rcp := NewRecipientFromAddress(addr)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedLeaseWithSig(pk, rcp, tc.amount, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -3725,14 +3725,14 @@ func TestLeaseWithSigBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx LeaseWithSig
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.ElementsMatch(t, *tx.Signature, *atx.Signature)
 				assert.ElementsMatch(t, pk, atx.SenderPK)
 				assert.ElementsMatch(t, addr, *atx.Recipient.Address)
@@ -3765,7 +3765,7 @@ func TestLeaseWithSigToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":8,\"version\":1,\"senderPublicKey\":\"%s\",\"recipient\":\"%s\",\"amount\":%d,\"fee\":%d,\"timestamp\":%d}", base58.Encode(pk[:]), tc.recipient, tc.amount, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":8,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"recipient\":\"%s\",\"amount\":%d,\"fee\":%d,\"timestamp\":%d}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), tc.recipient, tc.amount, tc.fee, ts)
 					assert.Equal(t, esj, string(sj))
@@ -3797,7 +3797,7 @@ func TestLeaseWithProofsValidations(t *testing.T) {
 		rcp, err := recipientFromString(tc.recipient)
 		require.NoError(t, err)
 		tx := NewUnsignedLeaseWithProofs(2, spk, rcp, tc.amount, tc.fee, 0)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -3895,7 +3895,7 @@ func TestLeaseWithProofsBinarySize(t *testing.T) {
 		rcp := NewRecipientFromAddress(addr)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedLeaseWithProofs(2, pk, rcp, tc.amount, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -3933,14 +3933,14 @@ func TestLeaseWithProofsBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx LeaseWithProofs
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.ElementsMatch(t, tx.Proofs.Proofs[0], atx.Proofs.Proofs[0])
 				assert.ElementsMatch(t, pk, atx.SenderPK)
 				assert.ElementsMatch(t, addr, *atx.Recipient.Address)
@@ -3973,7 +3973,7 @@ func TestLeaseWithProofsToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":8,\"version\":2,\"senderPublicKey\":\"%s\",\"recipient\":\"%s\",\"amount\":%d,\"fee\":%d,\"timestamp\":%d}", base58.Encode(pk[:]), tc.recipient, tc.amount, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":8,\"version\":2,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"recipient\":\"%s\",\"amount\":%d,\"fee\":%d,\"timestamp\":%d}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(pk[:]), tc.recipient, tc.amount, tc.fee, ts)
@@ -3997,7 +3997,7 @@ func TestLeaseCancelWithSigValidations(t *testing.T) {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		l, _ := crypto.NewDigestFromBase58(tc.lease)
 		tx := NewUnsignedLeaseCancelWithSig(spk, l, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -4043,23 +4043,23 @@ func TestLeaseCancelWithSigProtobufRoundTrip(t *testing.T) {
 		l, _ := crypto.NewDigestFromBase58(tc.lease)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedLeaseCancelWithSig(pk, l, tc.fee, ts)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx LeaseCancelWithSig
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx LeaseCancelWithSig
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -4082,7 +4082,7 @@ func TestLeaseCancelWithSigBinarySize(t *testing.T) {
 		l, _ := crypto.NewDigestFromBase58(tc.lease)
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		tx := NewUnsignedLeaseCancelWithSig(pk, l, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -4116,14 +4116,14 @@ func TestLeaseCancelWithSigBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx LeaseCancelWithSig
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.ElementsMatch(t, *tx.Signature, *atx.Signature)
 				assert.ElementsMatch(t, pk, atx.SenderPK)
 				assert.ElementsMatch(t, l, atx.LeaseID)
@@ -4152,7 +4152,7 @@ func TestLeaseCancelWithSigToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":9,\"version\":1,\"senderPublicKey\":\"%s\",\"leaseId\":\"%s\",\"fee\":%d,\"timestamp\":%d}", base58.Encode(pk[:]), tc.lease, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":9,\"version\":1,\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"leaseId\":\"%s\",\"fee\":%d,\"timestamp\":%d}", base58.Encode(tx.ID[:]), base58.Encode(tx.Signature[:]), base58.Encode(pk[:]), tc.lease, tc.fee, ts)
 					assert.Equal(t, esj, string(sj))
@@ -4176,7 +4176,7 @@ func TestLeaseCancelWithProofsValidations(t *testing.T) {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		l, _ := crypto.NewDigestFromBase58(tc.lease)
 		tx := NewUnsignedLeaseCancelWithProofs(2, 'T', spk, l, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -4356,7 +4356,7 @@ func TestCreateAliasWithSigValidations(t *testing.T) {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		a := NewAlias('W', tc.alias)
 		tx := NewUnsignedCreateAliasWithSig(spk, *a, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -4539,9 +4539,9 @@ func TestCreateAliasWithProofsValidations(t *testing.T) {
 	}
 	for _, tc := range tests {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
-		a := NewAlias(MainNetScheme, tc.alias)
+		a := NewAlias(TestNetScheme, tc.alias)
 		tx := NewUnsignedCreateAliasWithProofs(2, spk, *a, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -4754,7 +4754,7 @@ func TestMassTransferWithProofsValidations(t *testing.T) {
 		a, _ := NewOptionalAssetFromString(tc.asset)
 		att := []byte(tc.attachment)
 		tx := NewUnsignedMassTransferWithProofs(1, spk, *a, tc.transfers, tc.fee, 0, att)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -4859,7 +4859,7 @@ func TestMassTransferWithProofsBinarySize(t *testing.T) {
 		a, _ := NewOptionalAssetFromString(tc.asset)
 		att := []byte(tc.attachment)
 		tx := NewUnsignedMassTransferWithProofs(1, pk, *a, tc.transfers, tc.fee, ts, att)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -4900,14 +4900,14 @@ func TestMassTransferWithProofsBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Attachment, atx.Attachment)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx MassTransferWithProofs
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, len(tx.Proofs.Proofs), len(atx.Proofs.Proofs))
 				assert.ElementsMatch(t, tx.Proofs.Proofs, atx.Proofs.Proofs)
 				assert.Equal(t, pk, atx.SenderPK)
@@ -4961,7 +4961,7 @@ func TestMassTransferWithProofsToJSON(t *testing.T) {
 			}
 			ej := fmt.Sprintf(`{"type":11,"version":1,"senderPublicKey":"%s","assetId":%s,"transfers":[%s],"timestamp":%d,"fee":%d%s}`, base58.Encode(pk[:]), tc.expectedAsset, sb.String(), ts, tc.fee, tc.expectedAttachment)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":11,\"version\":1,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"assetId\":%s,\"transfers\":[%s],\"timestamp\":%d,\"fee\":%d%s}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(pk[:]), tc.expectedAsset, sb.String(), ts, tc.fee, tc.expectedAttachment)
@@ -5002,7 +5002,7 @@ func TestDataWithProofsValidations(t *testing.T) {
 		require.NoError(t, err)
 		tx := NewUnsignedDataWithProofs(1, spk, tc.fee, 0)
 		tx.Entries = tc.entries
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.Error(t, err, "#%d", i) //, tc.err, fmt.Sprintf("expected: %s", tc.err))
 		//assert.EqualError(t, err, tc.err, fmt.Sprintf("expected: %s", tc.err))
 		assert.Regexp(t, tc.err, err.Error(), "#%d", i)
@@ -5015,13 +5015,13 @@ func TestDataWithProofsDeleteValidation(t *testing.T) {
 	de := &DeleteDataEntry{Key: "key"}
 	tx1 := NewUnsignedDataWithProofs(1, spk, MinFee, 67890)
 	tx1.Entries = DataEntries{de}
-	_, err = tx1.Validate(MainNetScheme)
+	_, err = tx1.Validate(TestNetScheme)
 	msg := "delete supported only for protobuf transaction"
 	assert.EqualError(t, err, msg, fmt.Sprintf("expected: %s", msg))
 
 	tx2 := NewUnsignedDataWithProofs(2, spk, MinFee, 67890)
 	tx2.Entries = DataEntries{de}
-	_, err = tx2.Validate(MainNetScheme)
+	_, err = tx2.Validate(TestNetScheme)
 	assert.NoError(t, err)
 }
 
@@ -5052,18 +5052,18 @@ func TestDataWithProofsSizeLimit(t *testing.T) {
 		require.NoError(t, err)
 		tx := NewUnsignedDataWithProofs(1, spk, tc.fee, 0)
 		tx.Entries = tc.entries
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		require.NoError(t, err)
 
 		// Test custom format.
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
 		var tx2 DataWithProofs
-		err = tx2.UnmarshalBinary(txBytes, MainNetScheme)
+		err = tx2.UnmarshalBinary(txBytes, TestNetScheme)
 		assert.EqualError(t, err, tc.err, fmt.Sprintf("expected: %s", tc.err))
 
 		// Test Protobuf.
-		txBytes, err = tx.MarshalSignedToProtobuf(MainNetScheme)
+		txBytes, err = tx.MarshalSignedToProtobuf(TestNetScheme)
 		assert.NoError(t, err)
 		err = tx2.UnmarshalSignedFromProtobuf(txBytes)
 		assert.EqualError(t, err, tc.err, fmt.Sprintf("expected: %s", tc.err))
@@ -5143,23 +5143,23 @@ func TestDataWithProofsProtobufRoundTrip(t *testing.T) {
 			err := tx.AppendEntry(e)
 			assert.NoError(t, err)
 		}
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx DataWithProofs
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx DataWithProofs
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -5201,7 +5201,7 @@ func TestDataWithProofsBinarySize(t *testing.T) {
 			err := tx.AppendEntry(e)
 			assert.NoError(t, err)
 		}
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -5254,14 +5254,14 @@ func TestDataWithProofsBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx DataWithProofs
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.Equal(t, len(tx.Proofs.Proofs), len(atx.Proofs.Proofs))
 				assert.ElementsMatch(t, tx.Proofs.Proofs, atx.Proofs.Proofs)
 				assert.Equal(t, pk, atx.SenderPK)
@@ -5346,7 +5346,7 @@ func TestDataWithProofsToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":12,\"version\":1,\"senderPublicKey\":\"%s\",\"data\":[%s],\"fee\":%d,\"timestamp\":%d}", base58.Encode(pk[:]), sb.String(), tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":12,\"version\":1,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"data\":[%s],\"fee\":%d,\"timestamp\":%d}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(pk[:]), sb.String(), tc.fee, ts)
@@ -5410,8 +5410,8 @@ func TestSetScriptWithProofsValidations(t *testing.T) {
 	for _, tc := range tests {
 		spk, _ := crypto.NewPublicKeyFromBase58("BJ3Q8kNPByCWHwJ3RLn55UPzUDVgnh64EwYAU5iCj6z6")
 		s, _ := base58.Decode(tc.script)
-		tx := NewUnsignedSetScriptWithProofs(1, MainNetScheme, spk, s, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		tx := NewUnsignedSetScriptWithProofs(1, TestNetScheme, spk, s, tc.fee, 0)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -5602,7 +5602,7 @@ func TestSponsorshipWithProofsValidations(t *testing.T) {
 		a, err := crypto.NewDigestFromBase58("8Nwjd2tcQWff3S9WAhBa7vLRNpNnigWqrTbahvyfMVrU")
 		require.NoError(t, err)
 		tx := NewUnsignedSponsorshipWithProofs(1, spk, a, tc.minAssetFee, tc.fee, 0)
-		_, err = tx.Validate(MainNetScheme)
+		_, err = tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -5650,23 +5650,23 @@ func TestSponsorshipWithProofsProtobufRoundTrip(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		a, _ := crypto.NewDigestFromBase58(tc.asset)
 		tx := NewUnsignedSponsorshipWithProofs(1, pk, a, tc.assetFee, tc.fee, ts)
-		err = tx.GenerateID(MainNetScheme)
+		err = tx.GenerateID(TestNetScheme)
 		require.NoError(t, err)
-		if bb, err := tx.MarshalToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if bb, err := tx.MarshalToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx SponsorshipWithProofs
 			if err := atx.UnmarshalFromProtobuf(bb); assert.NoError(t, err) {
 				assert.Equal(t, *tx, atx)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
-		if b, err := tx.MarshalSignedToProtobuf(MainNetScheme); assert.NoError(t, err) {
+		if b, err := tx.MarshalSignedToProtobuf(TestNetScheme); assert.NoError(t, err) {
 			var atx SponsorshipWithProofs
 			if err := atx.UnmarshalSignedFromProtobuf(b); assert.NoError(t, err) {
-				err = atx.GenerateID(MainNetScheme)
+				err = atx.GenerateID(TestNetScheme)
 				assert.NoError(t, err)
 				assert.Equal(t, *tx, atx)
 			}
@@ -5690,7 +5690,7 @@ func TestSponsorshipWithProofsBinarySize(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		a, _ := crypto.NewDigestFromBase58(tc.asset)
 		tx := NewUnsignedSponsorshipWithProofs(1, pk, a, tc.assetFee, tc.fee, ts)
-		err = tx.Sign(MainNetScheme, sk)
+		err = tx.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NoError(t, err)
@@ -5726,14 +5726,14 @@ func TestSponsorshipWithProofsBinaryRoundTrip(t *testing.T) {
 				assert.Equal(t, tx.Timestamp, atx.Timestamp)
 			}
 		}
-		if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := tx.Verify(MainNetScheme, pk); assert.NoError(t, err) {
+		if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := tx.Verify(TestNetScheme, pk); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 		}
 		if b, err := tx.MarshalBinary(); assert.NoError(t, err) {
 			var atx SponsorshipWithProofs
-			if err := atx.UnmarshalBinary(b, MainNetScheme); assert.NoError(t, err) {
+			if err := atx.UnmarshalBinary(b, TestNetScheme); assert.NoError(t, err) {
 				assert.ElementsMatch(t, tx.Proofs.Proofs, atx.Proofs.Proofs)
 				assert.Equal(t, pk, atx.SenderPK)
 				assert.Equal(t, tc.asset, atx.AssetID.String())
@@ -5764,7 +5764,7 @@ func TestSponsorshipWithProofsToJSON(t *testing.T) {
 		if j, err := json.Marshal(tx); assert.NoError(t, err) {
 			ej := fmt.Sprintf("{\"type\":14,\"version\":1,\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"minSponsoredAssetFee\":%d,\"fee\":%d,\"timestamp\":%d}", base58.Encode(pk[:]), tc.asset, tc.assetFee, tc.fee, ts)
 			assert.Equal(t, ej, string(j))
-			if err := tx.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := tx.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if sj, err := json.Marshal(tx); assert.NoError(t, err) {
 					esj := fmt.Sprintf("{\"type\":14,\"version\":1,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"assetId\":\"%s\",\"minSponsoredAssetFee\":%d,\"fee\":%d,\"timestamp\":%d}",
 						base58.Encode(tx.ID[:]), base58.Encode(tx.Proofs.Proofs[0]), base58.Encode(pk[:]), tc.asset, tc.assetFee, tc.fee, ts)
@@ -5790,7 +5790,7 @@ func TestSetAssetScriptWithProofsValidations(t *testing.T) {
 		a, _ := crypto.NewDigestFromBase58("J8shEVBrQ4BLqsuYw5j6vQGCFJGMLBxr5nu2XvUWFEAR")
 		s, _ := base58.Decode(tc.script)
 		tx := NewUnsignedSetAssetScriptWithProofs(1, 'W', spk, a, s, tc.fee, 0)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -6014,7 +6014,7 @@ func TestInvokeScriptWithProofsValidations(t *testing.T) {
 		ad, _ := NewAddressFromString("3MrDis17gyNSusZDg8Eo1PuFnm5SQMda3gu")
 		fc := FunctionCall{Name: tc.name, Arguments: tc.args}
 		tx := NewUnsignedInvokeScriptWithProofs(tc.version, 'T', spk, NewRecipientFromAddress(ad), fc, tc.sps, *a2, tc.fee, 12345)
-		_, err := tx.Validate(MainNetScheme)
+		_, err := tx.Validate(TestNetScheme)
 		assert.EqualError(t, err, tc.err)
 	}
 }
@@ -6427,7 +6427,7 @@ func BenchmarkBytesToTransaction_WithReflection(b *testing.B) {
 	bts := []byte{0, 4, 2, 132, 79, 148, 251, 4, 38, 180, 107, 148, 225, 225, 107, 146, 125, 26, 243, 25, 35, 202, 83, 226, 142, 64, 8, 106, 72, 250, 228, 237, 132, 90, 16, 0, 0, 0, 0, 1, 104, 225, 147, 43, 220, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 134, 160, 1, 68, 152, 220, 142, 172, 155, 208, 202, 105, 149, 210, 120, 159, 30, 146, 64, 212, 101, 147, 228, 250, 36, 56, 81, 55, 0, 3, 102, 111, 111, 1, 0, 1, 0, 64, 154, 86, 48, 50, 47, 58, 64, 254, 146, 85, 72, 252, 23, 49, 64, 40, 34, 104, 117, 225, 126, 65, 235, 225, 38, 13, 114, 120, 7, 30, 240, 209, 37, 144, 166, 15, 14, 241, 232, 101, 103, 82, 232, 163, 165, 82, 96, 52, 132, 191, 194, 160, 155, 237, 106, 43, 82, 203, 125, 122, 219, 35, 186, 8}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := BytesToTransaction(bts, MainNetScheme)
+		_, err := BytesToTransaction(bts, TestNetScheme)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -6439,7 +6439,7 @@ func BenchmarkBytesToTransaction_WithoutReflection(b *testing.B) {
 	bts := []byte{0, 4, 2, 132, 79, 148, 251, 4, 38, 180, 107, 148, 225, 225, 107, 146, 125, 26, 243, 25, 35, 202, 83, 226, 142, 64, 8, 106, 72, 250, 228, 237, 132, 90, 16, 0, 0, 0, 0, 1, 104, 225, 147, 43, 220, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 134, 160, 1, 68, 152, 220, 142, 172, 155, 208, 202, 105, 149, 210, 120, 159, 30, 146, 64, 212, 101, 147, 228, 250, 36, 56, 81, 55, 0, 3, 102, 111, 111, 1, 0, 1, 0, 64, 154, 86, 48, 50, 47, 58, 64, 254, 146, 85, 72, 252, 23, 49, 64, 40, 34, 104, 117, 225, 126, 65, 235, 225, 38, 13, 114, 120, 7, 30, 240, 209, 37, 144, 166, 15, 14, 241, 232, 101, 103, 82, 232, 163, 165, 82, 96, 52, 132, 191, 194, 160, 155, 237, 106, 43, 82, 203, 125, 122, 219, 35, 186, 8}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := getTransaction(bts, MainNetScheme)
+		_, err := getTransaction(bts, TestNetScheme)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -6576,10 +6576,10 @@ func TestIssue_ToProtobufWithInvalidUtf8String(t *testing.T) {
 	s := string([]byte{0xE0, 0x80, 0x80})
 
 	is := NewUnsignedIssueWithSig(kp.Public, s, s, 100, 1, false, 1, 1)
-	err := is.Sign(MainNetScheme, kp.Secret)
+	err := is.Sign(TestNetScheme, kp.Secret)
 	require.NoError(t, err)
 
-	bts, err := is.MarshalSignedToProtobuf(MainNetScheme)
+	bts, err := is.MarshalSignedToProtobuf(TestNetScheme)
 	require.NoError(t, err)
 	require.NotEmpty(t, bts)
 }

--- a/pkg/proto/types_test.go
+++ b/pkg/proto/types_test.go
@@ -152,7 +152,7 @@ func TestOrderV1BinarySize(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV1(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee)
-		err = o.Sign(MainNetScheme, sk)
+		err = o.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		oBytes, err := o.MarshalBinary()
 		assert.NoError(t, err)
@@ -185,8 +185,8 @@ func TestOrderV1SigningRoundTrip(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV1(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee)
-		if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := o.Verify(MainNetScheme); assert.NoError(t, err) {
+		if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := o.Verify(TestNetScheme); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 			if b, err := o.MarshalBinary(); assert.NoError(t, err) {
@@ -253,7 +253,7 @@ func BenchmarkOrderV1SigningRoundTrip(t *testing.B) {
 	ts := uint64(time.Now().UnixNano() / 1000000)
 	exp := ts + 100*1000
 	o := NewUnsignedOrderV1(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee)
-	err := o.Sign(MainNetScheme, sk)
+	err := o.Sign(TestNetScheme, sk)
 	require.NoError(t, err)
 
 	t.Run("serialize", func(b *testing.B) {
@@ -321,7 +321,7 @@ func TestOrderV1ToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 				base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)
 			assert.JSONEq(t, ej, string(j))
-			if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if j, err := json.Marshal(o); assert.NoError(t, err) {
 					ej := fmt.Sprintf("{\"id\":\"%s\",\"signature\":\"%s\",\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 						base58.Encode(o.ID[:]), base58.Encode(o.Signature[:]), base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)
@@ -405,7 +405,7 @@ func TestOrderV2BinarySize(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV2(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee)
-		err = o.Sign(MainNetScheme, sk)
+		err = o.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		oBytes, err := o.MarshalBinary()
 		assert.NoError(t, err)
@@ -438,8 +438,8 @@ func TestOrderV2SigningRoundTrip(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV2(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee)
-		if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := o.Verify(MainNetScheme); assert.NoError(t, err) {
+		if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := o.Verify(TestNetScheme); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 			if b, err := o.MarshalBinary(); assert.NoError(t, err) {
@@ -499,7 +499,7 @@ func TestOrderV2ToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"version\":2,\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 				base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)
 			assert.JSONEq(t, ej, string(j))
-			if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if j, err := json.Marshal(o); assert.NoError(t, err) {
 					ej := fmt.Sprintf("{\"version\":2,\"id\":\"%s\",\"proofs\":[\"%s\"],\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 						base58.Encode(o.ID[:]), base58.Encode(o.Proofs.Proofs[0]), base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)
@@ -594,7 +594,7 @@ func TestOrderV3BinarySize(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV3(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee, *fa)
-		err = o.Sign(MainNetScheme, sk)
+		err = o.Sign(TestNetScheme, sk)
 		assert.NoError(t, err)
 		oBytes, err := o.MarshalBinary()
 		assert.NoError(t, err)
@@ -635,8 +635,8 @@ func TestOrderV3SigningRoundTrip(t *testing.T) {
 		ts := uint64(time.Now().UnixNano() / 1000000)
 		exp := ts + 100*1000
 		o := NewUnsignedOrderV3(pk, mpk, *aa, *pa, tc.orderType, tc.price, tc.amount, ts, exp, tc.fee, *fa)
-		if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
-			if r, err := o.Verify(MainNetScheme); assert.NoError(t, err) {
+		if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
+			if r, err := o.Verify(TestNetScheme); assert.NoError(t, err) {
 				assert.True(t, r)
 			}
 			if b, err := o.MarshalBinary(); assert.NoError(t, err) {
@@ -707,7 +707,7 @@ func TestOrderV3ToJSON(t *testing.T) {
 			ej := fmt.Sprintf("{\"version\":3,\"matcherFeeAssetId\":%s,\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 				fas, base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)
 			assert.JSONEq(t, ej, string(j))
-			if err := o.Sign(MainNetScheme, sk); assert.NoError(t, err) {
+			if err := o.Sign(TestNetScheme, sk); assert.NoError(t, err) {
 				if j, err := json.Marshal(o); assert.NoError(t, err) {
 					ej := fmt.Sprintf("{\"version\":3,\"id\":\"%s\",\"proofs\":[\"%s\"],\"matcherFeeAssetId\":%s,\"senderPublicKey\":\"%s\",\"matcherPublicKey\":\"%s\",\"assetPair\":{\"amountAsset\":%s,\"priceAsset\":%s},\"orderType\":\"%s\",\"price\":%d,\"amount\":%d,\"timestamp\":%d,\"expiration\":%d,\"matcherFee\":%d}",
 						base58.Encode(o.ID[:]), base58.Encode(o.Proofs.Proofs[0]), fas, base58.Encode(pk[:]), tc.matcher, aas, pas, tc.orderType.String(), tc.price, tc.amount, ts, exp, tc.fee)

--- a/pkg/ride/converters_test.go
+++ b/pkg/ride/converters_test.go
@@ -36,41 +36,41 @@ func (a *TransferWithSigTestSuite) SetupTest() {
 
 func (a *TransferWithSigTestSuite) Test_feeAssetId_Presence() {
 	a.tx.Transfer.FeeAsset = _asset
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(_digest.Bytes()), rs["feeAssetId"])
 }
 
 func (a *TransferWithSigTestSuite) Test_feeAssetId_Absence() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["feeAssetId"])
 }
 
 func (a *TransferWithSigTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["amount"])
 }
 
 func (a *TransferWithSigTestSuite) Test_assetId_presence() {
 	a.tx.Transfer.AmountAsset = _asset
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(_digest.Bytes()), rs["assetId"])
 }
 
 func (a *TransferWithSigTestSuite) Test_assetId_absence() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideUnit{}, rs["assetId"])
 }
 
 func (a *TransferWithSigTestSuite) Test_recipient() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideRecipient(a.tx.Recipient), rs["recipient"])
 }
 
 func (a *TransferWithSigTestSuite) Test_attachment() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	attachmentBytes, err := a.tx.Attachment.Bytes()
 	a.NoError(err)
@@ -78,52 +78,52 @@ func (a *TransferWithSigTestSuite) Test_attachment() {
 }
 
 func (a *TransferWithSigTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *TransferWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *TransferWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *TransferWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *TransferWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *TransferWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *TransferWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *TransferWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *TransferWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("TransferTransaction"), rs[instanceField])
 }
 
@@ -144,41 +144,41 @@ func (a *TransferWithProofsTestSuite) SetupTest() {
 
 func (a *TransferWithProofsTestSuite) Test_feeAssetId_Presence() {
 	a.tx.Transfer.FeeAsset = _asset
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(_digest.Bytes()), rs["feeAssetId"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_feeAssetId_Absence() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["feeAssetId"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_assetId_presence() {
 	a.tx.Transfer.AmountAsset = _asset
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(_digest.Bytes()), rs["assetId"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_assetId_absence() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideUnit{}, rs["assetId"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_recipient() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideRecipient(a.tx.Recipient), rs["recipient"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_attachment() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	attachmentBytes, err := a.tx.Attachment.Bytes()
 	a.NoError(err)
@@ -186,53 +186,53 @@ func (a *TransferWithProofsTestSuite) Test_attachment() {
 }
 
 func (a *TransferWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0].Bytes())
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *TransferWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *TransferWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("TransferTransaction"), rs[instanceField])
 }
 
@@ -256,36 +256,36 @@ func (a *GenesisTestSuite) SetupTest() {
 }
 
 func (a *GenesisTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *GenesisTestSuite) Test_recipient() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideRecipient(proto.NewRecipientFromAddress(a.tx.Recipient)), rs["recipient"])
 }
 
 func (a *GenesisTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
-	id, err := a.tx.GetID(proto.MainNetScheme)
+	id, err := a.tx.GetID(proto.TestNetScheme)
 	a.NoError(err)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *GenesisTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(0), rs["fee"])
 }
 
 func (a *GenesisTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *GenesisTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
@@ -309,64 +309,64 @@ func (a *PaymentTestSuite) SetupTest() {
 }
 
 func (a *PaymentTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *PaymentTestSuite) Test_recipient() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideRecipient(proto.NewRecipientFromAddress(a.tx.Recipient)), rs["recipient"])
 }
 
 func (a *PaymentTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
-	id, err := a.tx.GetID(proto.MainNetScheme)
+	id, err := a.tx.GetID(proto.TestNetScheme)
 	a.NoError(err)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *PaymentTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *PaymentTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *PaymentTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *PaymentTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *PaymentTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *PaymentTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *PaymentTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *PaymentTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("PaymentTransaction"), rs[instanceField])
 }
 
@@ -386,67 +386,67 @@ func (a *ReissueWithSigTestSuite) SetupTest() {
 }
 
 func (a *ReissueWithSigTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["quantity"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.AssetID.Bytes()), rs["assetId"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_reissuable() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBoolean(a.tx.Reissuable), rs["reissuable"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *ReissueWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *ReissueWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("ReissueTransaction"), rs[instanceField])
 }
 
@@ -467,68 +467,68 @@ func (a *ReissueWithProofsTestSuite) SetupTest() {
 }
 
 func (a *ReissueWithProofsTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["quantity"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.AssetID.Bytes()), rs["assetId"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_reissuable() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBoolean(a.tx.Reissuable), rs["reissuable"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *ReissueWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *ReissueWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("ReissueTransaction"), rs[instanceField])
 }
 
@@ -549,62 +549,62 @@ func (a *BurnWithSigTestSuite) SetupTest() {
 }
 
 func (a *BurnWithSigTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["quantity"])
 }
 
 func (a *BurnWithSigTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.AssetID.Bytes()), rs["assetId"])
 }
 
 func (a *BurnWithSigTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *BurnWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *BurnWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *BurnWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["version"])
 }
 
 func (a *BurnWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *BurnWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *BurnWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *BurnWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *BurnWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("BurnTransaction"), rs[instanceField])
 }
 
@@ -625,63 +625,63 @@ func (a *BurnWithProofsTestSuite) SetupTest() {
 }
 
 func (a *BurnWithProofsTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["quantity"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.AssetID.Bytes()), rs["assetId"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(2), rs["version"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *BurnWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *BurnWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("BurnTransaction"), rs[instanceField])
 }
 
@@ -703,26 +703,26 @@ func (a *MassTransferWithProofsTestSuite) SetupTest() {
 
 func (a *MassTransferWithProofsTestSuite) Test_assetId_presence() {
 	a.tx.Asset = _asset
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(_digest.Bytes()), rs["assetId"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_assetId_absence() {
 	a.tx.Asset = proto.OptionalAsset{}
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 
 	a.NoError(err)
 	a.Equal(rideUnit{}, rs["assetId"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_totalAmount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["totalAmount"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_transfers() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 
 	m := make(rideObject)
 	m["$instance"] = rideString("Transfer")
@@ -732,12 +732,12 @@ func (a *MassTransferWithProofsTestSuite) Test_transfers() {
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_transferCount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["transferCount"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_attachment() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	attachmentBytes, err := a.tx.Attachment.Bytes()
 	a.NoError(err)
@@ -745,53 +745,53 @@ func (a *MassTransferWithProofsTestSuite) Test_attachment() {
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["version"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *MassTransferWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("MassTransferTransaction"), rs[instanceField])
 }
 
@@ -812,81 +812,81 @@ func (a *ExchangeWithSigTestSuite) SetupTest() {
 }
 
 func (a *ExchangeWithSigTestSuite) Test_buyOrder() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Order", rs["buyOrder"].instanceOf())
 }
 
 func (a *ExchangeWithSigTestSuite) Test_sellOrder() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Order", rs["sellOrder"].instanceOf())
 }
 
 func (a *ExchangeWithSigTestSuite) Test_price() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["price"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_buyMatcherFee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["buyMatcherFee"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_sellMatcherFee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["sellMatcherFee"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["version"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 func (a *ExchangeWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *ExchangeWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *ExchangeWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("ExchangeTransaction"), rs[instanceField])
 }
 
@@ -907,83 +907,83 @@ func (a *ExchangeWithProofsTestSuite) SetupTest() {
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_price() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["price"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_buyOrder() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Order", rs["buyOrder"].instanceOf())
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_sellOrder() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Order", rs["sellOrder"].instanceOf())
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_buyMatcherFee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["buyMatcherFee"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_sellMatcherFee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["sellMatcherFee"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(2), rs["version"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *ExchangeWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("ExchangeTransaction"), rs[instanceField])
 }
 
@@ -1020,14 +1020,14 @@ func (a *OrderTestSuite) SetupTest() {
 		proto.Timestamp(1544715621),
 		10000)
 
-	a.NoError(sellOrder.Sign(proto.MainNetScheme, sk))
+	a.NoError(sellOrder.Sign(proto.TestNetScheme, sk))
 
 	a.tx = sellOrder
 	a.f = orderToObject
 }
 
 func (a *OrderTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	id, err := a.tx.GetID()
 	a.NoError(err)
@@ -1035,69 +1035,69 @@ func (a *OrderTestSuite) Test_id() {
 }
 
 func (a *OrderTestSuite) Test_matcherPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	tmp := a.tx.GetMatcherPK()
 	a.Equal(rideBytes(tmp.Bytes()), rs["matcherPublicKey"])
 }
 
 func (a *OrderTestSuite) Test_assetPair() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(assetPairToObject(a.aa, a.pa), rs["assetPair"])
 }
 
 func (a *OrderTestSuite) Test_orderType() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Sell", rs["orderType"].instanceOf())
 }
 
 func (a *OrderTestSuite) Test_price() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["price"])
 }
 
 func (a *OrderTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["amount"])
 }
 
 func (a *OrderTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(byte_helpers.TIMESTAMP)), rs["timestamp"])
 }
 
 func (a *OrderTestSuite) Test_expiration() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(byte_helpers.TIMESTAMP)), rs["expiration"])
 }
 
 func (a *OrderTestSuite) Test_matcherFee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(10000), rs["matcherFee"])
 }
 
 func (a *OrderTestSuite) Test_matcherFeeAssetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["matcherFeeAssetId"])
 }
 
 func (a *OrderTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := a.tx.GetSender(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := a.tx.GetSender(proto.TestNetScheme)
 	a.NoError(err)
-	wavesAddr, err := addr.ToWavesAddress(proto.MainNetScheme)
+	wavesAddr, err := addr.ToWavesAddress(proto.TestNetScheme)
 	a.NoError(err)
 	a.Equal(rideAddress(wavesAddr), rs["sender"])
 }
 
 func (a *OrderTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	pkBytes := a.tx.GetSenderPKBytes()
 	a.Equal(rideBytes(pkBytes), rs["senderPublicKey"])
 }
 
 func (a *OrderTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	proofs, _ := a.tx.GetProofs()
 	sig, _ := crypto.NewSignatureFromBytes(proofs.Proofs[0])
 	a.IsType(rideBytes{}, rs["bodyBytes"])
@@ -1105,13 +1105,13 @@ func (a *OrderTestSuite) Test_bodyBytes() {
 }
 
 func (a *OrderTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	p, _ := a.tx.GetProofs()
 	a.Equal(rideList{rideBytes(p.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *OrderTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("Order", rs.instanceOf())
 }
 
@@ -1151,27 +1151,27 @@ func (a *EthereumOrderV4TestSuite) SetupTest() {
 	)
 	sellOrder.Proofs = proto.NewProofs()
 
-	a.NoError(sellOrder.EthereumSign(proto.MainNetScheme, (*proto.EthereumPrivateKey)(sk)))
+	a.NoError(sellOrder.EthereumSign(proto.TestNetScheme, (*proto.EthereumPrivateKey)(sk)))
 
 	a.tx = sellOrder
 	a.f = orderToObject
 }
 
 func (a *EthereumOrderV4TestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	p, _ := a.tx.GetProofs()
 	a.NotNil(p)
 	a.Equal(rideList{_empty, _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *EthereumOrderV4TestSuite) Test_bodyBytes() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.Nil(rs["bodyBytes"])
 }
 
 func (a *EthereumOrderV4TestSuite) Test_matcherFeeAssetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.matcherFeeAssetID.ID.Bytes()), rs["matcherFeeAssetId"])
 }
 
@@ -1192,67 +1192,67 @@ func (a *SetAssetScriptWithProofsTestSuite) SetupTest() {
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_script() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	av, ok := rs["script"]
 	a.Assert().True(ok)
 	a.Equal(rideBytes("hello"), av)
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.AssetID.Bytes()), rs["assetId"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
-	id, err := a.tx.GetID(proto.MainNetScheme)
+	id, err := a.tx.GetID(proto.TestNetScheme)
 	a.NoError(err)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["version"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *SetAssetScriptWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("SetAssetScriptTransaction", rs.instanceOf())
 }
 
@@ -1273,12 +1273,12 @@ func (a *InvokeScriptWithProofsTestSuite) SetupTest() {
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_dappAddress() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideRecipient(a.tx.ScriptRecipient), rs["dApp"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_payment_presence() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	payment, ok := rs["payment"].(rideObject)
 	a.Assert().True(ok)
 	asset, ok := payment["assetId"]
@@ -1292,73 +1292,73 @@ func (a *InvokeScriptWithProofsTestSuite) Test_payment_presence() {
 
 func (a *InvokeScriptWithProofsTestSuite) Test_payment_absence() {
 	a.tx.Payments = nil
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["payment"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_feeAssetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(byte_helpers.Digest.Bytes()), rs["feeAssetId"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_function() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("funcname"), rs["function"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_args() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideString("StringArgument")}, rs["args"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_id() {
-	rs, err := a.f(proto.MainNetScheme, a.tx)
+	rs, err := a.f(proto.TestNetScheme, a.tx)
 	a.NoError(err)
 	a.Equal(rideBytes(a.tx.ID.Bytes()), rs["id"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1), rs["version"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *InvokeScriptWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("InvokeScriptTransaction", rs.instanceOf())
 }
 
@@ -1379,82 +1379,82 @@ func (a *IssueWithSigTestSuite) SetupTest() {
 }
 
 func (a *IssueWithSigTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1000), rs["quantity"])
 }
 
 func (a *IssueWithSigTestSuite) Test_name() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("name"), rs["name"])
 }
 
 func (a *IssueWithSigTestSuite) Test_description() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("description"), rs["description"])
 }
 
 func (a *IssueWithSigTestSuite) Test_reissuable() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBoolean(a.tx.Reissuable), rs["reissuable"])
 }
 
 func (a *IssueWithSigTestSuite) Test_decimals() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(4), rs["decimals"])
 }
 
 func (a *IssueWithSigTestSuite) Test_script() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["script"])
 }
 
 func (a *IssueWithSigTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *IssueWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *IssueWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *IssueWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *IssueWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *IssueWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *IssueWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *IssueWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *IssueWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("IssueTransaction", rs.instanceOf())
 }
 
@@ -1474,85 +1474,85 @@ func (a *IssueWithProofsTestSuite) SetupTest() {
 }
 
 func (a *IssueWithProofsTestSuite) Test_quantity() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1000), rs["quantity"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_name() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("name"), rs["name"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_description() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString("description"), rs["description"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_reissuable() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBoolean(a.tx.Reissuable), rs["reissuable"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_decimals() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(4), rs["decimals"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_script() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	av, ok := rs["script"]
 	a.Assert().True(ok)
 	a.Equal(rideBytes("script"), av)
 }
 
 func (a *IssueWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *IssueWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *IssueWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("IssueTransaction", rs.instanceOf())
 }
 
@@ -1573,62 +1573,62 @@ func (a *LeaseWithSigTestSuite) SetupTest() {
 }
 
 func (a *LeaseWithSigTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_recipient() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideRecipient(a.tx.Recipient), rs["recipient"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *LeaseWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *LeaseWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("LeaseTransaction", rs.instanceOf())
 }
 
@@ -1649,63 +1649,63 @@ func (a *LeaseWithProofsTestSuite) SetupTest() {
 }
 
 func (a *LeaseWithProofsTestSuite) Test_amount() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(100000), rs["amount"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_recipient() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideRecipient(a.tx.Recipient), rs["recipient"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *LeaseWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *LeaseWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("LeaseTransaction", rs.instanceOf())
 }
 
@@ -1726,57 +1726,57 @@ func (a *LeaseCancelWithSigTestSuite) SetupTest() {
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_leaseId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(_digest.Bytes()), rs["leaseId"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *LeaseCancelWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("LeaseCancelTransaction", rs.instanceOf())
 }
 
@@ -1797,58 +1797,58 @@ func (a *LeaseCancelWithProofsTestSuite) SetupTest() {
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_leaseId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.LeaseID.Bytes()), rs["leaseId"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *LeaseCancelWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("LeaseCancelTransaction", rs.instanceOf())
 }
 
@@ -1869,7 +1869,7 @@ func (a *DataWithProofsTestSuite) SetupTest() {
 }
 
 func (a *DataWithProofsTestSuite) Test_data() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	list, ok := rs["data"].(rideList)
 	a.Assert().True(ok)
 	o, ok := list[0].(rideObject)
@@ -1880,53 +1880,53 @@ func (a *DataWithProofsTestSuite) Test_data() {
 }
 
 func (a *DataWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *DataWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *DataWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *DataWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *DataWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *DataWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *DataWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *DataWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *DataWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("DataTransaction", rs.instanceOf())
 }
 
@@ -1947,69 +1947,69 @@ func (a *SponsorshipWithProofsTestSuite) SetupTest() {
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_assetId() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(_digest.Bytes()), rs["assetId"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_minSponsoredAssetFee_presence() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(1000), rs["minSponsoredAssetFee"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_minSponsoredAssetFee_absence() {
 	a.tx.MinAssetFee = 0
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideUnit{}, rs["minSponsoredAssetFee"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *SponsorshipWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("SponsorFeeTransaction", rs.instanceOf())
 }
 
@@ -2030,57 +2030,57 @@ func (a *CreateAliasWithSigTestSuite) SetupTest() {
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_alias() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString(a.tx.Alias.Alias), rs["alias"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	a.True(crypto.Verify(pub, *a.tx.Signature, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Signature.Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *CreateAliasWithSigTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("CreateAliasTransaction", rs.instanceOf())
 }
 
@@ -2101,58 +2101,58 @@ func (a *CreateAliasWithProofsTestSuite) SetupTest() {
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_alias() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideString(a.tx.Alias.Alias), rs["alias"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_id() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	id, _ := a.tx.GetID(proto.MainNetScheme)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	id, _ := a.tx.GetID(proto.TestNetScheme)
 	a.Equal(rideBytes(id), rs["id"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_fee() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Fee)), rs["fee"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_timestamp() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Timestamp)), rs["timestamp"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_version() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideInt(int64(a.tx.Version)), rs["version"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_sender() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, a.tx.SenderPK)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, a.tx.SenderPK)
 	a.NoError(err)
 	a.Equal(rideAddress(addr), rs["sender"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_senderPublicKey() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideBytes(a.tx.SenderPK.Bytes()), rs["senderPublicKey"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_bodyBytes() {
 	_, pub, _ := crypto.GenerateKeyPair([]byte("test"))
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.IsType(rideBytes{}, rs["bodyBytes"])
 	sig, _ := crypto.NewSignatureFromBytes(a.tx.Proofs.Proofs[0])
 	a.True(crypto.Verify(pub, sig, rs["bodyBytes"].(rideBytes)))
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_proofs() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal(rideList{rideBytes(a.tx.Proofs.Proofs[0].Bytes()), _empty, _empty, _empty, _empty, _empty, _empty, _empty}, rs["proofs"])
 }
 
 func (a *CreateAliasWithProofsTestSuite) Test_instanceFieldName() {
-	rs, _ := a.f(proto.MainNetScheme, a.tx)
+	rs, _ := a.f(proto.TestNetScheme, a.tx)
 	a.Equal("CreateAliasTransaction", rs.instanceOf())
 }
 
@@ -2186,12 +2186,12 @@ func TestEthereumTransferWavesTransformTxToRideObj(t *testing.T) {
 	txData := defaultEthLegacyTxData(1000000000000000, &recipientEth, nil, 100000)
 	tx := proto.NewEthereumTransaction(txData, proto.NewEthereumTransferWavesTxKind(), &crypto.Digest{}, &senderPK, 0)
 
-	rideObj, err := transactionToObject(proto.MainNetScheme, &tx)
+	rideObj, err := transactionToObject(proto.TestNetScheme, &tx)
 	assert.NoError(t, err)
 
-	sender, err := tx.WavesAddressFrom(proto.MainNetScheme)
+	sender, err := tx.WavesAddressFrom(proto.TestNetScheme)
 	assert.NoError(t, err)
-	recipient, err := tx.WavesAddressTo(proto.MainNetScheme)
+	recipient, err := tx.WavesAddressTo(proto.TestNetScheme)
 	assert.NoError(t, err)
 	assert.Equal(t, rideBytes(senderPK.SerializeXYCoordinates()), rideObj["senderPublicKey"])
 	assert.Equal(t, rideAddress(sender), rideObj["sender"])
@@ -2242,16 +2242,16 @@ func TestEthereumTransferAssetsTransformTxToRideObj(t *testing.T) {
 
 	tx.TxKind = proto.NewEthereumTransferAssetsErc20TxKind(*decodedData, *proto.NewOptionalAssetFromDigest(asset.ID), erc20arguments)
 
-	rideObj, err := transactionToObject(proto.MainNetScheme, &tx)
+	rideObj, err := transactionToObject(proto.TestNetScheme, &tx)
 	assert.NoError(t, err)
 
-	sender, err := tx.WavesAddressFrom(proto.MainNetScheme)
+	sender, err := tx.WavesAddressFrom(proto.TestNetScheme)
 	assert.NoError(t, err)
 
 	assert.Equal(t, rideBytes(senderPK.SerializeXYCoordinates()), rideObj["senderPublicKey"])
 	assert.Equal(t, rideAddress(sender), rideObj["sender"])
 
-	erc20TransferRecipient, err := proto.EthereumAddress(erc20arguments.Recipient).ToWavesAddress(proto.MainNetScheme)
+	erc20TransferRecipient, err := proto.EthereumAddress(erc20arguments.Recipient).ToWavesAddress(proto.TestNetScheme)
 	assert.NoError(t, err)
 
 	assert.Equal(t, rideRecipient(proto.NewRecipientFromAddress(erc20TransferRecipient)), rideObj["recipient"])

--- a/pkg/ride/tree_evaluation_test.go
+++ b/pkg/ride/tree_evaluation_test.go
@@ -503,7 +503,7 @@ func TestDataFunctions(t *testing.T) {
 		Key:   "string",
 		Value: "world",
 	}))
-	require.NoError(t, data.Sign(proto.MainNetScheme, secret))
+	require.NoError(t, data.Sign(proto.TestNetScheme, secret))
 	txObj, err := transactionToObject('W', data)
 	require.NoError(t, err)
 	env := &mockRideEnvironment{
@@ -543,7 +543,7 @@ func TestDataFunctions(t *testing.T) {
 
 func testInvokeEnv(verifier bool) (environment, *proto.InvokeScriptWithProofs) {
 	tx := byte_helpers.InvokeScriptWithProofs.Transaction.Clone()
-	txo, err := transactionToObject(proto.MainNetScheme, tx)
+	txo, err := transactionToObject(proto.TestNetScheme, tx)
 	if err != nil {
 		panic(err)
 	}
@@ -551,7 +551,7 @@ func testInvokeEnv(verifier bool) (environment, *proto.InvokeScriptWithProofs) {
 	env := &mockRideEnvironment{
 		invocationFunc: func() rideObject {
 			if !verifier {
-				obj, err := invocationToObject(3, proto.MainNetScheme, tx)
+				obj, err := invocationToObject(3, proto.TestNetScheme, tx)
 				if err != nil {
 					panic(err)
 				}
@@ -560,7 +560,7 @@ func testInvokeEnv(verifier bool) (environment, *proto.InvokeScriptWithProofs) {
 			return txo
 		},
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		txIDFunc: func() rideType {
 			return rideBytes(tx.ID.Bytes())
@@ -659,7 +659,7 @@ func TestDappDefaultFunc(t *testing.T) {
 	   }
 	*/
 	env, tx := testInvokeEnv(false)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, tx.SenderPK)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, tx.SenderPK)
 	require.NoError(t, err)
 
 	code := "AAIDAAAAAAAAAAAAAAABAQAAABFnZXRQcmV2aW91c0Fuc3dlcgAAAAEAAAAHYWRkcmVzcwUAAAAHYWRkcmVzcwAAAAIAAAABaQEAAAAGdGVsbG1lAAAAAQAAAAhxdWVzdGlvbgQAAAAGYW5zd2VyCQEAAAARZ2V0UHJldmlvdXNBbnN3ZXIAAAABBQAAAAhxdWVzdGlvbgkBAAAACFdyaXRlU2V0AAAAAQkABEwAAAACCQEAAAAJRGF0YUVudHJ5AAAAAgkAASwAAAACBQAAAAZhbnN3ZXICAAAAAl9xBQAAAAhxdWVzdGlvbgkABEwAAAACCQEAAAAJRGF0YUVudHJ5AAAAAgkAASwAAAACBQAAAAZhbnN3ZXICAAAAAl9hBQAAAAZhbnN3ZXIFAAAAA25pbAAAAAppbnZvY2F0aW9uAQAAAAdkZWZhdWx0AAAAAAQAAAAHc2VuZGVyMAgIBQAAAAppbnZvY2F0aW9uAAAABmNhbGxlcgAAAAVieXRlcwkBAAAACFdyaXRlU2V0AAAAAQkABEwAAAACCQEAAAAJRGF0YUVudHJ5AAAAAgIAAAABYQIAAAABYgkABEwAAAACCQEAAAAJRGF0YUVudHJ5AAAAAgIAAAAGc2VuZGVyBQAAAAdzZW5kZXIwBQAAAANuaWwAAAABAAAAAnR4AQAAAAZ2ZXJpZnkAAAAACQAAAAAAAAIJAQAAABFnZXRQcmV2aW91c0Fuc3dlcgAAAAEJAAQlAAAAAQgFAAAAAnR4AAAABnNlbmRlcgIAAAABMcP91gY="
@@ -772,7 +772,7 @@ func TestTransferSet(t *testing.T) {
 	   }
 	*/
 	env, tx := testInvokeEnv(false)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, tx.SenderPK)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, tx.SenderPK)
 	require.NoError(t, err)
 	code := "AAIDAAAAAAAAAAAAAAAAAAAAAQAAAAFpAQAAAAZ0ZWxsbWUAAAABAAAACHF1ZXN0aW9uCQEAAAALVHJhbnNmZXJTZXQAAAABCQAETAAAAAIJAQAAAA5TY3JpcHRUcmFuc2ZlcgAAAAMIBQAAAAFpAAAABmNhbGxlcgAAAAAAAAAAZAUAAAAEdW5pdAUAAAADbmlsAAAAAH5a2L0="
 	_, tree := parseBase64Script(t, code)
@@ -821,7 +821,7 @@ func TestScriptResult(t *testing.T) {
 	   }
 	*/
 	env, tx := testInvokeEnv(false)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, tx.SenderPK)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, tx.SenderPK)
 	require.NoError(t, err)
 	code := "AAIDAAAAAAAAAAAAAAAAAAAAAQAAAAFpAQAAAAZ0ZWxsbWUAAAABAAAACHF1ZXN0aW9uCQEAAAAMU2NyaXB0UmVzdWx0AAAAAgkBAAAACFdyaXRlU2V0AAAAAQkABEwAAAACCQEAAAAJRGF0YUVudHJ5AAAAAgIAAAADa2V5AAAAAAAAAABkBQAAAANuaWwJAQAAAAtUcmFuc2ZlclNldAAAAAEJAARMAAAAAgkBAAAADlNjcmlwdFRyYW5zZmVyAAAAAwgFAAAAAWkAAAAGY2FsbGVyAAAAAAAAAYiUBQAAAAR1bml0BQAAAANuaWwAAAAARKRntw=="
 	_, tree := parseBase64Script(t, code)
@@ -1799,7 +1799,7 @@ func TestInvokeDAppFromDAppScript1(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -1809,7 +1809,7 @@ func TestInvokeDAppFromDAppScript1(t *testing.T) {
 		Timestamp:       1564703444249,
 	}
 
-	inv, _ = invocationToObject(4, proto.MainNetScheme, tx)
+	inv, _ = invocationToObject(4, proto.TestNetScheme, tx)
 
 	firstScript = "AAIFAAAAAAAAAAYIAhIAEgAAAAAAAAAAAgAAAAFpAQAAAANiYXIAAAAACQAFFAAAAAIJAARMAAAAAgkBAAAADEludGVnZXJFbnRyeQAAAAICAAAAA2JhcgAAAAAAAAAAAQUAAAADbmlsAgAAAAZyZXR1cm4AAAABaQEAAAADZm9vAAAAAAQAAAABcgkAA/wAAAAEBQAAAAR0aGlzAgAAAANiYXIFAAAAA25pbAUAAAADbmlsAwkAAAAAAAACBQAAAAFyAgAAAAZyZXR1cm4EAAAABGRhdGEJAQAAABFAZXh0ck5hdGl2ZSgxMDUwKQAAAAIFAAAABHRoaXMCAAAAA2JhcgMJAAAAAAAAAgUAAAAEZGF0YQAAAAAAAAAAAQkABEwAAAACCQEAAAAMSW50ZWdlckVudHJ5AAAAAgIAAAADa2V5AAAAAAAAAAABBQAAAANuaWwJAAACAAAAAQIAAAAJQmFkIHN0YXRlCQAAAgAAAAECAAAAEkJhZCByZXR1cm5lZCB2YWx1ZQAAAADz23Fz"
 
@@ -2594,7 +2594,7 @@ func TestInvokeDAppFromDAppScript6(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -2603,7 +2603,7 @@ func TestInvokeDAppFromDAppScript6(t *testing.T) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	inv, _ = invocationToObject(4, proto.MainNetScheme, tx)
+	inv, _ = invocationToObject(4, proto.TestNetScheme, tx)
 
 	firstScript = "AAIFAAAAAAAAAAQIAhIAAAAAAAAAAAEAAAABaQEAAAADZm9vAAAAAAQAAAABcgkAA/wAAAAEBQAAAAR0aGlzAgAAAANmb28FAAAAA25pbAUAAAADbmlsAwkAAAAAAAACBQAAAAFyBQAAAAFyBQAAAANuaWwJAAACAAAAAQIAAAAJSW1wb3NpYmxlAAAAAAWzLtA="
 
@@ -2699,7 +2699,7 @@ func BenchmarkInvokeDAppFromDAppScript6(b *testing.B) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -2708,7 +2708,7 @@ func BenchmarkInvokeDAppFromDAppScript6(b *testing.B) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	inv, _ = invocationToObject(4, proto.MainNetScheme, tx)
+	inv, _ = invocationToObject(4, proto.TestNetScheme, tx)
 
 	firstScript = "AAIFAAAAAAAAAAQIAhIAAAAAAAAAAAEAAAABaQEAAAADZm9vAAAAAAQAAAABcgkAA/wAAAAEBQAAAAR0aGlzAgAAAANmb28FAAAAA25pbAUAAAADbmlsAwkAAAAAAAACBQAAAAFyBQAAAAFyBQAAAANuaWwJAAACAAAAAQIAAAAJSW1wb3NpYmxlAAAAAAWzLtA="
 
@@ -2786,7 +2786,7 @@ func TestReentrantInvokeDAppFromDAppScript6(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -2795,7 +2795,7 @@ func TestReentrantInvokeDAppFromDAppScript6(t *testing.T) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	inv, _ = invocationToObject(4, proto.MainNetScheme, tx)
+	inv, _ = invocationToObject(4, proto.TestNetScheme, tx)
 
 	firstScript = "AAIFAAAAAAAAAAQIAhIAAAAAAAAAAAEAAAABaQEAAAADZm9vAAAAAAQAAAABcgkAA/0AAAAEBQAAAAR0aGlzAgAAAANmb28FAAAAA25pbAUAAAADbmlsAwkAAAAAAAACBQAAAAFyBQAAAAFyBQAAAANuaWwJAAACAAAAAQIAAAAJSW1wb3NpYmxlAAAAALQe43c=\n"
 
@@ -3241,7 +3241,7 @@ func TestInvokeDAppFromDAppSmartAssetValidation(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -3250,7 +3250,7 @@ func TestInvokeDAppFromDAppSmartAssetValidation(t *testing.T) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	inv, _ = invocationToObject(5, proto.MainNetScheme, tx)
+	inv, _ = invocationToObject(5, proto.TestNetScheme, tx)
 
 	firstScript = "AAIFAAAAAAAAAAQIAhIAAAAAAQAAAAAHYXNzZXRJZAEAAAAgAKdAj/iZUd+zAOo6DTO6IvheatMyaLi7as+C+lV4EDMAAAABAAAAAWkBAAAABHRlc3QAAAAABAAAAANyZXMJAAP8AAAABAkBAAAAB0FkZHJlc3MAAAABAQAAABoBV0myKgvnUpvnQwgi/Cmpjg8vaC8j0MoKywIAAAAEY2FsbAUAAAADbmlsBQAAAANuaWwDCQAAAAAAAAIFAAAAA3JlcwAAAAAAAAAAEQUAAAADbmlsCQAAAgAAAAECAAAAEkJhZCByZXR1cm5lZCB2YWx1ZQAAAAAnQdRv"
 	secondScript = "AAIFAAAAAAAAAAQIAhIAAAAAAQAAAAAHYXNzZXRJZAEAAAAgAKdAj/iZUd+zAOo6DTO6IvheatMyaLi7as+C+lV4EDMAAAABAAAAAWkBAAAABGNhbGwAAAAACQAFFAAAAAIJAARMAAAAAgkBAAAAB1JlaXNzdWUAAAADBQAAAAdhc3NldElkAAAAAAAAAABkBwkABEwAAAACCQEAAAAEQnVybgAAAAIFAAAAB2Fzc2V0SWQAAAAAAAAAADIJAARMAAAAAgkBAAAADlNjcmlwdFRyYW5zZmVyAAAAAwgFAAAAAWkAAAAGY2FsbGVyAAAAAAAAAAABBQAAAAdhc3NldElkBQAAAANuaWwAAAAAAAAAABEAAAAA4X8UHg=="
@@ -4165,7 +4165,7 @@ func TestHashScriptFunc(t *testing.T) {
 	require.NoError(t, err)
 	addrPK, err := crypto.NewPublicKeyFromBase58("2zb2orX2g58YZgXAvdn5ojTuPP8vAU2rsqYQ5L6KCXqz")
 	require.NoError(t, err)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, addrPK)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, addrPK)
 	require.NoError(t, err)
 	recipient := proto.NewRecipientFromAddress(addr)
 
@@ -4181,7 +4181,7 @@ func TestHashScriptFunc(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        senderPK,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -4190,7 +4190,7 @@ func TestHashScriptFunc(t *testing.T) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	inv, _ := invocationToObject(5, proto.MainNetScheme, tx)
+	inv, _ := invocationToObject(5, proto.TestNetScheme, tx)
 
 	var script string
 	var wrappedSt WrappedState
@@ -4210,7 +4210,7 @@ func TestHashScriptFunc(t *testing.T) {
 	}
 	env := &mockRideEnvironment{
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		heightFunc: func() rideInt {
 			return 368430
@@ -4225,7 +4225,7 @@ func TestHashScriptFunc(t *testing.T) {
 			return 1564703444249
 		},
 		transactionFunc: func() rideObject {
-			obj, _ := transactionToObject(proto.MainNetScheme, tx)
+			obj, _ := transactionToObject(proto.TestNetScheme, tx)
 			return obj
 		},
 		stateFunc: func() types.SmartState {
@@ -4290,7 +4290,7 @@ func TestDataStorageUntouchedFunc(t *testing.T) {
 
 	addrPK, err := crypto.NewPublicKeyFromBase58("2zb2orX2g58YZgXAvdn5ojTuPP8vAU2rsqYQ5L6KCXqz")
 	require.NoError(t, err)
-	addr, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, addrPK)
+	addr, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, addrPK)
 	require.NoError(t, err)
 	recipient := proto.NewRecipientFromAddress(addr)
 
@@ -4306,7 +4306,7 @@ func TestDataStorageUntouchedFunc(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        senderPK,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -4315,7 +4315,7 @@ func TestDataStorageUntouchedFunc(t *testing.T) {
 		Fee:             900000,
 		Timestamp:       1564703444249,
 	}
-	//inv, _ := invocationToObject(5, proto.MainNetScheme, tx)
+	//inv, _ := invocationToObject(5, proto.TestNetScheme, tx)
 
 	var script string
 	var wrappedSt WrappedState
@@ -4333,7 +4333,7 @@ func TestDataStorageUntouchedFunc(t *testing.T) {
 	}
 	env := &mockRideEnvironment{
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		heightFunc: func() rideInt {
 			return 368430
@@ -4345,7 +4345,7 @@ func TestDataStorageUntouchedFunc(t *testing.T) {
 			return 1564703444249
 		},
 		transactionFunc: func() rideObject {
-			obj, _ := transactionToObject(proto.MainNetScheme, tx)
+			obj, _ := transactionToObject(proto.TestNetScheme, tx)
 			return obj
 		},
 		stateFunc: func() types.SmartState {
@@ -4422,7 +4422,7 @@ func TestMatchOverwrite(t *testing.T) {
 
 	env := &mockRideEnvironment{
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		heightFunc: func() rideInt {
 			return 368430
@@ -4574,12 +4574,12 @@ func TestFailSript2(t *testing.T) {
 	err := json.Unmarshal([]byte(transaction), tx)
 	require.NoError(t, err)
 
-	tv, err := transactionToObject(proto.MainNetScheme, tx)
+	tv, err := transactionToObject(proto.TestNetScheme, tx)
 	require.NoError(t, err)
 
 	env := &mockRideEnvironment{
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		heightFunc: func() rideInt {
 			return 368430
@@ -6509,7 +6509,7 @@ func TestZeroReissue(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -6760,7 +6760,7 @@ func TestStageNet2(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        sender,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -7094,7 +7094,7 @@ func TestOriginCaller(t *testing.T) {
 	proofs := proto.NewProofs()
 	senderPK, err := crypto.NewPublicKeyFromBase58("EY3etWLNnrLg4znKsncuJFXVUHiP61PYpuZTAED98QUS")
 	require.NoError(t, err)
-	senderAddress, err := proto.NewAddressFromPublicKey(proto.MainNetScheme, senderPK)
+	senderAddress, err := proto.NewAddressFromPublicKey(proto.TestNetScheme, senderPK)
 	require.NoError(t, err)
 	dApp1, err := proto.NewAddressFromString("3PH75p2rmMKCV2nyW4TsAdFgFtmc61mJaqA")
 	require.NoError(t, err)
@@ -7112,7 +7112,7 @@ func TestOriginCaller(t *testing.T) {
 		Version:         1,
 		ID:              &txID,
 		Proofs:          proofs,
-		ChainID:         proto.MainNetScheme,
+		ChainID:         proto.TestNetScheme,
 		SenderPK:        senderPK,
 		ScriptRecipient: recipient,
 		FunctionCall:    call,
@@ -7121,19 +7121,19 @@ func TestOriginCaller(t *testing.T) {
 		Fee:             500000,
 		Timestamp:       1624967106278,
 	}
-	testInv, err := invocationToObject(5, proto.MainNetScheme, tx)
+	testInv, err := invocationToObject(5, proto.TestNetScheme, tx)
 	require.NoError(t, err)
 	testDAppAddress := dApp1
 	env := &mockRideEnvironment{
 		schemeFunc: func() byte {
-			return proto.MainNetScheme
+			return proto.TestNetScheme
 		},
 		thisFunc: func() rideType {
 			return rideAddress(testDAppAddress)
 		},
 		rideV6ActivatedFunc: noRideV6,
 		transactionFunc: func() rideObject {
-			obj, err := transactionToObject(proto.MainNetScheme, tx)
+			obj, err := transactionToObject(proto.TestNetScheme, tx)
 			require.NoError(t, err)
 			return obj
 		},

--- a/pkg/ride/vm_test.go
+++ b/pkg/ride/vm_test.go
@@ -119,7 +119,7 @@ func newDataTransaction() *proto.DataWithProofs {
 	tx.Entries = append(tx.Entries, &proto.BinaryDataEntry{Key: "binary", Value: []byte{0xCA, 0xFE, 0xBE, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF}})
 	tx.Entries = append(tx.Entries, &proto.StringDataEntry{Key: "string", Value: "Hello, World!"})
 	tx.Entries = append(tx.Entries, &proto.IntegerDataEntry{Key: "someKey", Value: 12345})
-	err = tx.Sign(proto.MainNetScheme, sk)
+	err = tx.Sign(proto.TestNetScheme, sk)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/state/block_differ_test.go
+++ b/pkg/state/block_differ_test.go
@@ -19,7 +19,7 @@ type blockDifferTestObjects struct {
 }
 
 func createBlockDiffer(t *testing.T) (*blockDifferTestObjects, []string) {
-	sets := settings.MainNetSettings
+	sets := settings.TestNetSettings
 	stor, path, err := createStorageObjects()
 	require.NoError(t, err, "createStorageObjects() failed")
 	handler, err := newTransactionHandler(sets.Genesis.BlockID(), stor.entities, sets)
@@ -34,18 +34,18 @@ func genBlocks(t *testing.T, to *blockDifferTestObjects) (*proto.Block, *proto.B
 	txs := proto.Transactions{createTransferWithSig(t)}
 	randSig := genRandBlockIds(t, 1)[0]
 	genSig := crypto.MustBytesFromBase58(defaultGenSig)
-	parent, err := proto.CreateBlock(txs, 1565694219644, randSig, testGlobal.matcherInfo.pk, proto.NxtConsensus{BaseTarget: 65, GenSignature: genSig}, proto.NgBlockVersion, nil, -1, proto.MainNetScheme)
+	parent, err := proto.CreateBlock(txs, 1565694219644, randSig, testGlobal.matcherInfo.pk, proto.NxtConsensus{BaseTarget: 65, GenSignature: genSig}, proto.NgBlockVersion, nil, -1, proto.TestNetScheme)
 	require.NoError(t, err, "CreateBlock() failed")
-	err = parent.Sign(proto.MainNetScheme, testGlobal.matcherInfo.sk)
+	err = parent.Sign(proto.TestNetScheme, testGlobal.matcherInfo.sk)
 	require.NoError(t, err, "Block.Sign() failed")
 
 	// Create and sign child block.
 	txs = []proto.Transaction{createIssueWithSig(t, 1000)}
 	genSig, err = to.gsp.GenerationSignature(testGlobal.minerInfo.pk, parent.GenSignature[:])
 	require.NoError(t, err, "GeneratorSignature() failed")
-	child, err := proto.CreateBlock(txs, 1565694219944, parent.BlockID(), testGlobal.minerInfo.pk, proto.NxtConsensus{BaseTarget: 66, GenSignature: genSig}, proto.NgBlockVersion, nil, -1, proto.MainNetScheme)
+	child, err := proto.CreateBlock(txs, 1565694219944, parent.BlockID(), testGlobal.minerInfo.pk, proto.NxtConsensus{BaseTarget: 66, GenSignature: genSig}, proto.NgBlockVersion, nil, -1, proto.TestNetScheme)
 	require.NoError(t, err, "CreateBlock() failed")
-	err = child.Sign(proto.MainNetScheme, testGlobal.minerInfo.sk)
+	err = child.Sign(proto.TestNetScheme, testGlobal.minerInfo.sk)
 	require.NoError(t, err, "Block.Sign() failed")
 	return parent, child
 }
@@ -162,7 +162,7 @@ func TestCreateBlockDiffSponsorship(t *testing.T) {
 func genTransferWithWavesFee(t *testing.T) *proto.TransferWithProofs {
 	waves := proto.NewOptionalAssetWaves()
 	tx := proto.NewUnsignedTransferWithProofs(2, testGlobal.senderInfo.pk, waves, waves, defaultTimestamp, defaultAmount, defaultFee, proto.NewRecipientFromAddress(testGlobal.recipientInfo.addr), []byte("attachment"))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	require.NoError(t, err)
 	return tx
 }
@@ -171,11 +171,11 @@ func genBlockWithSingleTransaction(t *testing.T, prevID proto.BlockID, prevGenSi
 	txs := proto.Transactions{genTransferWithWavesFee(t)}
 	genSig, err := to.gsp.GenerationSignature(testGlobal.minerInfo.pk, prevGenSig)
 	require.NoError(t, err)
-	block, err := proto.CreateBlock(txs, 1565694219944, prevID, testGlobal.minerInfo.pk, proto.NxtConsensus{BaseTarget: 66, GenSignature: genSig}, proto.RewardBlockVersion, nil, -1, proto.MainNetScheme)
+	block, err := proto.CreateBlock(txs, 1565694219944, prevID, testGlobal.minerInfo.pk, proto.NxtConsensus{BaseTarget: 66, GenSignature: genSig}, proto.RewardBlockVersion, nil, -1, proto.TestNetScheme)
 	require.NoError(t, err)
 	block.BlockHeader.Version = proto.RewardBlockVersion
 	block.BlockHeader.RewardVote = 700000000
-	err = block.Sign(proto.MainNetScheme, testGlobal.minerInfo.sk)
+	err = block.Sign(proto.TestNetScheme, testGlobal.minerInfo.sk)
 	require.NoError(t, err)
 	return block
 }

--- a/pkg/state/ethereum_tx_test.go
+++ b/pkg/state/ethereum_tx_test.go
@@ -68,7 +68,7 @@ func defaultTxAppender(t *testing.T, storage scriptStorageState, state types.Sma
 	return txAppender
 }
 func defaultEthereumLegacyTxData(value int64, to *proto.EthereumAddress, data []byte, gas uint64, scheme proto.Scheme) *proto.EthereumLegacyTx {
-	v := big.NewInt(int64(scheme)) // MainNet byte
+	v := big.NewInt(int64(scheme)) // TestNet byte
 	v.Mul(v, big.NewInt(2))
 	v.Add(v, big.NewInt(35))
 
@@ -85,14 +85,14 @@ func defaultEthereumLegacyTxData(value int64, to *proto.EthereumAddress, data []
 func TestEthereumTransferWaves(t *testing.T) {
 	appendTxParams := defaultAppendTxParams()
 	//assetsUncertain := newAssets
-	txAppender := defaultTxAppender(t, nil, nil, nil, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, nil, nil, nil, proto.TestNetScheme)
 	senderPK, err := proto.NewEthereumPublicKeyFromHexString("c4f926702fee2456ac5f3d91c9b7aa578ff191d0792fa80b6e65200f2485d9810a89c1bb5830e6618119fb3f2036db47fac027f7883108cbc7b2953539b9cb53")
 	assert.NoError(t, err)
 	recipientBytes, err := base58.Decode("a783d1CBABe28d25E64aDf84477C4687c1411f94") // 0x241Cf7eaf669E0d2FDe4Ba3a534c20B433F4c43d
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 100000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 100000, proto.TestNetScheme)
 	tx := proto.NewEthereumTransaction(txData, nil, nil, &senderPK, 0)
 	tx.TxKind, err = txAppender.ethInfo.ethereumTransactionKind(&tx, nil)
 
@@ -101,12 +101,12 @@ func TestEthereumTransferWaves(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, applRes.status)
 
-	sender, err := senderPK.EthereumAddress().ToWavesAddress(proto.MainNetScheme)
+	sender, err := senderPK.EthereumAddress().ToWavesAddress(proto.TestNetScheme)
 	assert.NoError(t, err)
 
 	wavesAsset := proto.NewOptionalAssetWaves()
 	senderKey := byteKey(sender.ID(), wavesAsset)
-	recipient, err := recipientEth.ToWavesAddress(proto.MainNetScheme)
+	recipient, err := recipientEth.ToWavesAddress(proto.TestNetScheme)
 	assert.NoError(t, err)
 	recipientKey := byteKey(recipient.ID(), wavesAsset)
 	senderBalance := applRes.changes.diff[string(senderKey)].balance
@@ -141,7 +141,7 @@ func TestEthereumTransferAssets(t *testing.T) {
 	assetsUncertain := map[proto.AssetID]assetInfo{
 		proto.AssetID(recipientEth): {},
 	}
-	txAppender := defaultTxAppender(t, storage, &AnotherMockSmartState{}, assetsUncertain, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, storage, &AnotherMockSmartState{}, assetsUncertain, proto.TestNetScheme)
 	/*
 		from https://etherscan.io/tx/0x363f979b58c82614db71229c2a57ed760e7bc454ee29c2f8fd1df99028667ea5
 		transfer(address,uint256)
@@ -153,7 +153,7 @@ func TestEthereumTransferAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	//0x989393922c92e07c209f67636731bf1f04871d8b
-	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, data, 100000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, data, 100000, proto.TestNetScheme)
 	tx := proto.NewEthereumTransaction(txData, nil, nil, &senderPK, 0)
 
 	db := ethabi.NewErc20MethodsMap()
@@ -175,7 +175,7 @@ func TestEthereumTransferAssets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, applRes.status)
 
-	sender, err := senderPK.EthereumAddress().ToWavesAddress(proto.MainNetScheme)
+	sender, err := senderPK.EthereumAddress().ToWavesAddress(proto.TestNetScheme)
 	assert.NoError(t, err)
 
 	wavesAsset := proto.NewOptionalAssetWaves()
@@ -185,7 +185,7 @@ func TestEthereumTransferAssets(t *testing.T) {
 	rideEthRecipientAddress, ok := decodedData.Inputs[0].Value.(ethabi.Bytes)
 	assert.True(t, ok)
 	ethRecipientAddress := proto.BytesToEthereumAddress(rideEthRecipientAddress)
-	recipient, err := ethRecipientAddress.ToWavesAddress(proto.MainNetScheme)
+	recipient, err := ethRecipientAddress.ToWavesAddress(proto.TestNetScheme)
 	assert.NoError(t, err)
 	recipientKey := byteKey(recipient.ID(), *proto.NewOptionalAssetFromDigest(fullAssetID))
 	senderWavesBalance := applRes.changes.diff[string(senderWavesKey)].balance
@@ -261,9 +261,9 @@ func TestEthereumInvoke(t *testing.T) {
 	assetsUncertain := map[proto.AssetID]assetInfo{
 		proto.AssetID(recipientEth): {},
 	}
-	txAppender := defaultTxAppender(t, storage, state, assetsUncertain, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, storage, state, assetsUncertain, proto.TestNetScheme)
 
-	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.TestNetScheme)
 	decodedData := defaultDecodedData("call", []ethabi.DecodedArg{{Value: ethabi.Int(10)}}, []ethabi.Payment{{Amount: 5, AssetID: proto.NewOptionalAssetWaves().ID}})
 	txKind := proto.NewEthereumInvokeScriptTxKind(decodedData)
 	tx := proto.NewEthereumTransaction(txData, txKind, &crypto.Digest{}, &senderPK, 0)
@@ -283,7 +283,7 @@ func TestEthereumInvoke(t *testing.T) {
 	assert.Equal(t, expectedDataEntryWrites[0], res.ScriptActions()[0])
 
 	// fee test
-	txDataForFeeCheck := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 499999, proto.MainNetScheme)
+	txDataForFeeCheck := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 499999, proto.TestNetScheme)
 	tx = proto.NewEthereumTransaction(txDataForFeeCheck, txKind, &crypto.Digest{}, &senderPK, 0)
 
 	_, err = txAppender.ia.txHandler.checkTx(&tx, fallibleInfo.checkerInfo)
@@ -292,14 +292,14 @@ func TestEthereumInvoke(t *testing.T) {
 
 func TestTransferZeroAmount(t *testing.T) {
 	appendTxParams := defaultAppendTxParams()
-	txAppender := defaultTxAppender(t, nil, nil, nil, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, nil, nil, nil, proto.TestNetScheme)
 	senderPK, err := proto.NewEthereumPublicKeyFromHexString("c4f926702fee2456ac5f3d91c9b7aa578ff191d0792fa80b6e65200f2485d9810a89c1bb5830e6618119fb3f2036db47fac027f7883108cbc7b2953539b9cb53")
 	assert.NoError(t, err)
 	recipientBytes, err := base58.Decode("a783d1CBABe28d25E64aDf84477C4687c1411f94") // 0x241Cf7eaf669E0d2FDe4Ba3a534c20B433F4c43d
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(0, &recipientEth, nil, 100000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(0, &recipientEth, nil, 100000, proto.TestNetScheme)
 	tx := proto.NewEthereumTransaction(txData, nil, nil, &senderPK, 0)
 	tx.TxKind, err = txAppender.ethInfo.ethereumTransactionKind(&tx, nil)
 	assert.NoError(t, err)
@@ -308,7 +308,7 @@ func TestTransferZeroAmount(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTransferMainNetTestnet(t *testing.T) {
+func TestTransferTestNetTestnet(t *testing.T) {
 	appendTxParams := defaultAppendTxParams()
 	txAppender := defaultTxAppender(t, nil, nil, nil, proto.TestNetScheme)
 	senderPK, err := proto.NewEthereumPublicKeyFromHexString("c4f926702fee2456ac5f3d91c9b7aa578ff191d0792fa80b6e65200f2485d9810a89c1bb5830e6618119fb3f2036db47fac027f7883108cbc7b2953539b9cb53")
@@ -317,7 +317,7 @@ func TestTransferMainNetTestnet(t *testing.T) {
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(100, &recipientEth, nil, 100000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(100, &recipientEth, nil, 100000, proto.TestNetScheme)
 	tx := proto.NewEthereumTransaction(txData, nil, nil, &senderPK, 0)
 	tx.TxKind, err = txAppender.ethInfo.ethereumTransactionKind(&tx, nil)
 	assert.NoError(t, err)
@@ -335,7 +335,7 @@ func TestTransferCheckFee(t *testing.T) {
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(100, &recipientEth, nil, 100, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(100, &recipientEth, nil, 100, proto.TestNetScheme)
 	tx := proto.NewEthereumTransaction(txData, nil, nil, &senderPK, 0)
 	tx.TxKind, err = txAppender.ethInfo.ethereumTransactionKind(&tx, nil)
 	assert.NoError(t, err)
@@ -383,7 +383,7 @@ func TestEthereumInvokeWithoutPaymentsAndArguments(t *testing.T) {
 			return 3, nil
 		},
 	}
-	txAppender := defaultTxAppender(t, storage, state, nil, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, storage, state, nil, proto.TestNetScheme)
 	senderPK, err := proto.NewEthereumPublicKeyFromHexString("c4f926702fee2456ac5f3d91c9b7aa578ff191d0792fa80b6e65200f2485d9810a89c1bb5830e6618119fb3f2036db47fac027f7883108cbc7b2953539b9cb53")
 	assert.NoError(t, err)
 	sender, err := senderPK.EthereumAddress().ToWavesAddress(0)
@@ -392,7 +392,7 @@ func TestEthereumInvokeWithoutPaymentsAndArguments(t *testing.T) {
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.TestNetScheme)
 	decodedData := defaultDecodedData("call", nil, nil)
 	tx := proto.NewEthereumTransaction(txData, proto.NewEthereumInvokeScriptTxKind(decodedData), &crypto.Digest{}, &senderPK, 0)
 
@@ -451,7 +451,7 @@ func TestEthereumInvokeAllArguments(t *testing.T) {
 			return 3, nil
 		},
 	}
-	txAppender := defaultTxAppender(t, storage, state, nil, proto.MainNetScheme)
+	txAppender := defaultTxAppender(t, storage, state, nil, proto.TestNetScheme)
 	senderPK, err := proto.NewEthereumPublicKeyFromHexString("c4f926702fee2456ac5f3d91c9b7aa578ff191d0792fa80b6e65200f2485d9810a89c1bb5830e6618119fb3f2036db47fac027f7883108cbc7b2953539b9cb53")
 	assert.NoError(t, err)
 	sender, err := senderPK.EthereumAddress().ToWavesAddress(0)
@@ -460,7 +460,7 @@ func TestEthereumInvokeAllArguments(t *testing.T) {
 	assert.NoError(t, err)
 	recipientEth := proto.BytesToEthereumAddress(recipientBytes)
 
-	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.MainNetScheme)
+	txData := defaultEthereumLegacyTxData(1000000000000000, &recipientEth, nil, 500000, proto.TestNetScheme)
 	decodedData := defaultDecodedData("call", []ethabi.DecodedArg{
 		{Value: ethabi.Int(1)},
 		{Value: ethabi.Bool(true)},

--- a/pkg/state/transaction_differ_test.go
+++ b/pkg/state/transaction_differ_test.go
@@ -69,7 +69,7 @@ func TestCreateDiffGenesis(t *testing.T) {
 
 func createPayment(t *testing.T) *proto.Payment {
 	tx := proto.NewUnsignedPayment(testGlobal.senderInfo.pk, testGlobal.recipientInfo.addr, defaultAmount, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -103,7 +103,7 @@ func TestCreateDiffPayment(t *testing.T) {
 
 func createTransferWithSig(t *testing.T) *proto.TransferWithSig {
 	tx := proto.NewUnsignedTransferWithSig(testGlobal.senderInfo.pk, *(testGlobal.asset0.asset), *(testGlobal.asset0.asset), defaultTimestamp, defaultAmount, defaultFee, proto.NewRecipientFromAddress(testGlobal.recipientInfo.addr), []byte("attachment"))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -167,7 +167,7 @@ func TestCreateDiffTransferWithSig(t *testing.T) {
 
 func createTransferWithProofs(t *testing.T) *proto.TransferWithProofs {
 	tx := proto.NewUnsignedTransferWithProofs(2, testGlobal.senderInfo.pk, *(testGlobal.asset0.asset), *(testGlobal.asset0.asset), defaultTimestamp, defaultAmount, defaultFee, proto.NewRecipientFromAddress(testGlobal.recipientInfo.addr), []byte("attachment"))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -231,14 +231,14 @@ func TestCreateDiffTransferWithProofs(t *testing.T) {
 
 func createIssueWithSig(t *testing.T, feeUnits int) *proto.IssueWithSig {
 	tx := proto.NewUnsignedIssueWithSig(testGlobal.senderInfo.pk, "name", "description", defaultQuantity, defaultDecimals, true, defaultTimestamp, uint64(feeUnits*FeeUnit))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
 
 func createNFTIssueWithSig(t *testing.T) *proto.IssueWithSig {
 	tx := proto.NewUnsignedIssueWithSig(testGlobal.senderInfo.pk, "nft", "nft asset", 1, 0, false, defaultTimestamp, defaultFee)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -272,14 +272,14 @@ func TestCreateDiffIssueWithSig(t *testing.T) {
 
 func createIssueWithProofs(t *testing.T, feeUnits int) *proto.IssueWithProofs {
 	tx := proto.NewUnsignedIssueWithProofs(2, 'W', testGlobal.senderInfo.pk, "name", "description", defaultQuantity, defaultDecimals, true, testGlobal.scriptBytes, defaultTimestamp, uint64(feeUnits*FeeUnit))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
 
 func createNFTIssueWithProofs(t *testing.T) *proto.IssueWithProofs {
 	tx := proto.NewUnsignedIssueWithProofs(2, 'W', testGlobal.senderInfo.pk, "nfg", "nft like asset", 1, 0, false, testGlobal.scriptBytes, defaultTimestamp, defaultFee)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -313,7 +313,7 @@ func TestCreateDiffIssueWithProofs(t *testing.T) {
 
 func createReissueWithSig(t *testing.T, feeUnits int) *proto.ReissueWithSig {
 	tx := proto.NewUnsignedReissueWithSig(testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, defaultQuantity, false, defaultTimestamp, uint64(feeUnits*FeeUnit))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -346,7 +346,7 @@ func TestCreateDiffReissueWithSig(t *testing.T) {
 
 func createReissueWithProofs(t *testing.T, feeUnits int) *proto.ReissueWithProofs {
 	tx := proto.NewUnsignedReissueWithProofs(2, 'W', testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, defaultQuantity, false, defaultTimestamp, uint64(feeUnits*FeeUnit))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -379,7 +379,7 @@ func TestCreateDiffReissueWithProofs(t *testing.T) {
 
 func createBurnWithSig(t *testing.T) *proto.BurnWithSig {
 	tx := proto.NewUnsignedBurnWithSig(testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, defaultAmount, defaultTimestamp, defaultFee)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -412,7 +412,7 @@ func TestCreateDiffBurnWithSig(t *testing.T) {
 
 func createBurnWithProofs(t *testing.T) *proto.BurnWithProofs {
 	tx := proto.NewUnsignedBurnWithProofs(2, 'W', testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, defaultAmount, defaultTimestamp, defaultFee)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -445,13 +445,13 @@ func TestCreateDiffBurnWithProofs(t *testing.T) {
 
 func createExchangeWithSig(t *testing.T) *proto.ExchangeWithSig {
 	bo := proto.NewUnsignedOrderV1(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, 10e8, 100, 0, 0, 3)
-	err := bo.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := bo.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "bo.Sign() failed")
 	so := proto.NewUnsignedOrderV1(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, 10e8, 100, 0, 0, 3)
-	err = so.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+	err = so.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 	assert.NoError(t, err, "so.Sign() failed")
 	tx := proto.NewUnsignedExchangeWithSig(bo, so, bo.Price, bo.Amount, 1, 2, defaultFee, defaultTimestamp)
-	err = tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err = tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -459,13 +459,13 @@ func createExchangeWithSig(t *testing.T) *proto.ExchangeWithSig {
 //TODO: this function is used in test that is commented for now
 //func createExchangeWithSigParams(t *testing.T, price, amount uint64) *proto.ExchangeWithSig {
 //	bo := proto.NewUnsignedOrderV1(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, price, amount, 0, 0, 3)
-//	err := bo.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+//	err := bo.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 //	assert.NoError(t, err, "bo.Sign() failed")
 //	so := proto.NewUnsignedOrderV1(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, price, amount, 0, 0, 3)
-//	err = so.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+//	err = so.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 //	assert.NoError(t, err, "so.Sign() failed")
 //	tx := proto.NewUnsignedExchangeWithSig(bo, so, bo.Price, bo.Amount, 1, 2, defaultFee, defaultTimestamp)
-//	err = tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+//	err = tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 //	assert.NoError(t, err, "tx.Sign() failed")
 //	return tx
 //}
@@ -506,26 +506,26 @@ func TestCreateDiffExchangeWithSig(t *testing.T) {
 
 func createExchangeWithProofs(t *testing.T) *proto.ExchangeWithProofs {
 	bo := proto.NewUnsignedOrderV2(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, 10e8, 100, 0, 0, 3)
-	err := bo.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := bo.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "bo.Sign() failed")
 	so := proto.NewUnsignedOrderV2(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, 10e8, 100, 0, 0, 3)
-	err = so.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+	err = so.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 	assert.NoError(t, err, "so.Sign() failed")
 	tx := proto.NewUnsignedExchangeWithProofs(2, bo, so, bo.Price, bo.Amount, 1, 2, defaultFee, defaultTimestamp)
-	err = tx.Sign(proto.MainNetScheme, testGlobal.matcherInfo.sk)
+	err = tx.Sign(proto.TestNetScheme, testGlobal.matcherInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
 
 func createUnorderedExchangeWithProofs(t *testing.T, v int) *proto.ExchangeWithProofs {
 	bo := proto.NewUnsignedOrderV3(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, 10e8, 100, 0, 0, 3, *testGlobal.asset2.asset)
-	err := bo.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := bo.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "bo.Sign() failed")
 	so := proto.NewUnsignedOrderV3(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, 10e8, 100, 0, 0, 3, *testGlobal.asset2.asset)
-	err = so.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+	err = so.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 	assert.NoError(t, err, "so.Sign() failed")
 	tx := proto.NewUnsignedExchangeWithProofs(byte(v), so, bo, bo.Price, bo.Amount, 1, 2, defaultFee, defaultTimestamp)
-	err = tx.Sign(proto.MainNetScheme, testGlobal.matcherInfo.sk)
+	err = tx.Sign(proto.TestNetScheme, testGlobal.matcherInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -583,17 +583,17 @@ func createExchangeWithProofsWithMixedOrders(t *testing.T, txVersion byte, buyIn
 	switch buyInfo.orderBuildTypeID {
 	case orderV3:
 		boV3 := proto.NewUnsignedOrderV3(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, buyInfo.price, buyInfo.amount, 0, 0, 3, *testGlobal.asset2.asset)
-		err := boV3.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+		err := boV3.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 		require.NoError(t, err, "boV3.Sign() failed")
 		bo = boV3
 	case orderV4:
 		boV4 := proto.NewUnsignedOrderV4(testGlobal.senderInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, buyInfo.price, buyInfo.amount, 0, 0, 3, *testGlobal.asset2.asset, proto.OrderPriceModeDefault)
-		err := boV4.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+		err := boV4.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 		require.NoError(t, err, "boV4.Sign() failed")
 		bo = boV4
 	case ethereumOrderV4:
 		eboV4 := proto.NewUnsignedEthereumOrderV4(&testGlobal.senderEthInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Buy, buyInfo.price, buyInfo.amount, 0, 0, 3, *testGlobal.asset2.asset, proto.OrderPriceModeDefault)
-		err := eboV4.EthereumSign(proto.MainNetScheme, &testGlobal.senderEthInfo.sk)
+		err := eboV4.EthereumSign(proto.TestNetScheme, &testGlobal.senderEthInfo.sk)
 		require.NoError(t, err, "eboV4.EthereumSign() failed")
 		bo = eboV4
 	default:
@@ -605,17 +605,17 @@ func createExchangeWithProofsWithMixedOrders(t *testing.T, txVersion byte, buyIn
 	switch sellInfo.orderBuildTypeID {
 	case orderV3:
 		soV3 := proto.NewUnsignedOrderV3(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, sellInfo.price, sellInfo.amount, 0, 0, 3, *testGlobal.asset2.asset)
-		err := soV3.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+		err := soV3.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 		require.NoError(t, err, "soV3.Sign() failed")
 		so = soV3
 	case orderV4:
 		soV4 := proto.NewUnsignedOrderV4(testGlobal.recipientInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, sellInfo.price, sellInfo.amount, 0, 0, 3, *testGlobal.asset2.asset, proto.OrderPriceModeDefault)
-		err := soV4.Sign(proto.MainNetScheme, testGlobal.recipientInfo.sk)
+		err := soV4.Sign(proto.TestNetScheme, testGlobal.recipientInfo.sk)
 		require.NoError(t, err, "soV4.Sign() failed")
 		so = soV4
 	case ethereumOrderV4:
 		esoV4 := proto.NewUnsignedEthereumOrderV4(&testGlobal.recipientEthInfo.pk, testGlobal.matcherInfo.pk, *testGlobal.asset0.asset, *testGlobal.asset1.asset, proto.Sell, sellInfo.price, sellInfo.amount, 0, 0, 3, *testGlobal.asset2.asset, proto.OrderPriceModeDefault)
-		err := esoV4.EthereumSign(proto.MainNetScheme, &testGlobal.recipientEthInfo.sk)
+		err := esoV4.EthereumSign(proto.TestNetScheme, &testGlobal.recipientEthInfo.sk)
 		require.NoError(t, err, "esoV4.EthereumSign() failed")
 		so = esoV4
 	default:
@@ -624,7 +624,7 @@ func createExchangeWithProofsWithMixedOrders(t *testing.T, txVersion byte, buyIn
 	}
 
 	tx := proto.NewUnsignedExchangeWithProofs(txVersion, bo, so, sellInfo.price, bo.GetAmount(), 1, 2, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.matcherInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.matcherInfo.sk)
 	require.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -910,7 +910,7 @@ func TestCreateDiffExchangeV3WithProofsWithOrdersV4(t *testing.T) {
 
 func createLeaseWithSig(t *testing.T) *proto.LeaseWithSig {
 	tx := proto.NewUnsignedLeaseWithSig(testGlobal.senderInfo.pk, proto.NewRecipientFromAddress(testGlobal.recipientInfo.addr), defaultAmount, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -944,7 +944,7 @@ func TestCreateDiffLeaseWithSig(t *testing.T) {
 
 func createLeaseWithProofs(t *testing.T) *proto.LeaseWithProofs {
 	tx := proto.NewUnsignedLeaseWithProofs(2, testGlobal.senderInfo.pk, proto.NewRecipientFromAddress(testGlobal.recipientInfo.addr), defaultAmount, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -978,7 +978,7 @@ func TestCreateDiffLeaseWithProofs(t *testing.T) {
 
 func createLeaseCancelWithSig(t *testing.T, leaseID crypto.Digest) *proto.LeaseCancelWithSig {
 	tx := proto.NewUnsignedLeaseCancelWithSig(testGlobal.senderInfo.pk, leaseID, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1018,7 +1018,7 @@ func TestCreateDiffLeaseCancelWithSig(t *testing.T) {
 
 func createLeaseCancelWithProofs(t *testing.T, leaseID crypto.Digest) *proto.LeaseCancelWithProofs {
 	tx := proto.NewUnsignedLeaseCancelWithProofs(2, 'W', testGlobal.senderInfo.pk, leaseID, defaultFee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1062,7 +1062,7 @@ func createCreateAliasWithSig(t *testing.T) *proto.CreateAliasWithSig {
 	alias, err := proto.NewAliasFromString(aliasFull)
 	assert.NoError(t, err, "NewAliasFromString() failed")
 	tx := proto.NewUnsignedCreateAliasWithSig(testGlobal.senderInfo.pk, *alias, defaultFee, defaultTimestamp)
-	err = tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err = tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1098,7 +1098,7 @@ func createCreateAliasWithProofs(t *testing.T) *proto.CreateAliasWithProofs {
 	alias, err := proto.NewAliasFromString(aliasFull)
 	assert.NoError(t, err, "NewAliasFromString() failed")
 	tx := proto.NewUnsignedCreateAliasWithProofs(2, testGlobal.senderInfo.pk, *alias, defaultFee, defaultTimestamp)
-	err = tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err = tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1141,7 +1141,7 @@ func generateMassTransferEntries(t *testing.T, entriesNum int) []proto.MassTrans
 
 func createMassTransferWithProofs(t *testing.T, transfers []proto.MassTransferEntry) *proto.MassTransferWithProofs {
 	tx := proto.NewUnsignedMassTransferWithProofs(1, testGlobal.senderInfo.pk, *testGlobal.asset0.asset, transfers, defaultFee, defaultTimestamp, []byte("attachment"))
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1188,7 +1188,7 @@ func createDataWithProofs(t *testing.T, entriesNum int) *proto.DataWithProofs {
 		entry := &proto.IntegerDataEntry{Key: "TheKey", Value: int64(666)}
 		tx.Entries = append(tx.Entries, entry)
 	}
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "Sign() failed")
 	return tx
 }
@@ -1220,7 +1220,7 @@ func TestCreateDiffDataWithProofs(t *testing.T) {
 
 func createSponsorshipWithProofs(t *testing.T, fee uint64) *proto.SponsorshipWithProofs {
 	tx := proto.NewUnsignedSponsorshipWithProofs(1, testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, defaultQuantity, FeeUnit*fee, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1254,7 +1254,7 @@ func createSetScriptWithProofs(t *testing.T) *proto.SetScriptWithProofs {
 	feeConst, ok := feeConstants[proto.SetScriptTransaction]
 	assert.Equal(t, ok, true)
 	tx := proto.NewUnsignedSetScriptWithProofs(1, 'W', testGlobal.senderInfo.pk, testGlobal.scriptBytes, FeeUnit*feeConst, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1288,7 +1288,7 @@ func createSetAssetScriptWithProofs(t *testing.T) *proto.SetAssetScriptWithProof
 	feeConst, ok := feeConstants[proto.SetAssetScriptTransaction]
 	assert.Equal(t, ok, true)
 	tx := proto.NewUnsignedSetAssetScriptWithProofs(1, 'W', testGlobal.senderInfo.pk, testGlobal.asset0.asset.ID, testGlobal.scriptBytes, FeeUnit*feeConst, defaultTimestamp)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1329,7 +1329,7 @@ func createInvokeScriptWithProofs(t *testing.T, pmts proto.ScriptPayments, fc pr
 		fee,
 		defaultTimestamp,
 	)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1398,7 +1398,7 @@ func TestCreateDiffInvokeScriptWithProofs(t *testing.T) {
 
 func createUpdateAssetInfoWithProofs(t *testing.T) *proto.UpdateAssetInfoWithProofs {
 	tx := proto.NewUnsignedUpdateAssetInfoWithProofs(1, 'W', testGlobal.asset0.asset.ID, testGlobal.senderInfo.pk, "noname", "someDescription", defaultTimestamp, *(testGlobal.asset1.asset), defaultFee)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }
@@ -1437,7 +1437,7 @@ func createInvokeExpressionWithProofs(t *testing.T, expression proto.B64Bytes, f
 		fee,
 		defaultTimestamp,
 	)
-	err := tx.Sign(proto.MainNetScheme, testGlobal.senderInfo.sk)
+	err := tx.Sign(proto.TestNetScheme, testGlobal.senderInfo.sk)
 	assert.NoError(t, err, "tx.Sign() failed")
 	return tx
 }

--- a/pkg/state/verifier_test.go
+++ b/pkg/state/verifier_test.go
@@ -58,39 +58,39 @@ func TestVerifier(t *testing.T) {
 
 	// Test valid blocks.
 	chans := newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	err = verifyBlocks(blocks, chans)
 	assert.NoError(t, err, "verifyBlocks() failed with valid blocks")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	// Test valid transactions.
 	err = verifyTransactions(txs, chans)
 	assert.NoError(t, err, "verifyTransactions() failed with valid transactions")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	// Spoil block parent.
 	backup := blocks[len(blocks)/2]
 	blocks[len(blocks)/2].Parent = proto.NewBlockIDFromSignature(crypto.Signature{})
 	err = verifyBlocks(blocks, chans)
 	assert.Error(t, err, "verifyBlocks() did not fail with wrong parent")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	blocks[len(blocks)/2] = backup
 	err = verifyBlocks(blocks, chans)
 	assert.NoError(t, err, "verifyBlocks() failed with valid blocks")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	// Spoil block signature.
 	blocks[len(blocks)/2].BlockSignature = crypto.Signature{}
 	err = verifyBlocks(blocks, chans)
 	assert.Error(t, err, "verifyBlocks() did not fail with wrong signature")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	blocks[len(blocks)/2] = backup
 	err = verifyBlocks(blocks, chans)
 	assert.NoError(t, err, "verifyBlocks() failed with valid blocks")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	// Test unsigned tx failure.
 	spk, err := crypto.NewPublicKeyFromBase58(testPK)
 	assert.NoError(t, err, "NewPublicKeyFromBase58() failed")
@@ -102,7 +102,7 @@ func TestVerifier(t *testing.T) {
 	err = verifyTransactions(txs, chans)
 	assert.Error(t, err, "verifyTransactions() did not fail with unsigned tx")
 	chans = newVerifierChans()
-	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.MainNetScheme)
+	go launchVerifier(context.Background(), chans, runtime.NumCPU(), proto.TestNetScheme)
 	// Test invalid tx failure.
 	invalidTx := proto.NewUnsignedGenesis(recipient, 0, 0)
 	txs = []proto.Transaction{invalidTx}

--- a/pkg/wallet/embedded_wallet_test.go
+++ b/pkg/wallet/embedded_wallet_test.go
@@ -24,7 +24,7 @@ func TestEmbeddedWalletImpl_SignTransactionWith(t *testing.T) {
 		tx := byte_helpers.TransferWithSig.Transaction.Clone()
 		tx.SenderPK = pub
 
-		w := NewEmbeddedWallet(nil, seederTest("test"), proto.MainNetScheme)
+		w := NewEmbeddedWallet(nil, seederTest("test"), proto.TestNetScheme)
 		err = w.SignTransactionWith(pub, tx)
 		require.NoError(t, err)
 	})
@@ -33,7 +33,7 @@ func TestEmbeddedWalletImpl_SignTransactionWith(t *testing.T) {
 		tx := byte_helpers.TransferWithSig.Transaction.Clone()
 		tx.SenderPK = pub
 
-		w := NewEmbeddedWallet(nil, seederTest("test"), proto.MainNetScheme)
+		w := NewEmbeddedWallet(nil, seederTest("test"), proto.TestNetScheme)
 		err = w.SignTransactionWith(crypto.PublicKey{}, tx)
 		require.Equal(t, PublicKeyNotFound, err)
 	})
@@ -55,18 +55,18 @@ func TestEmbeddedWalletImpl_Load(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
-		w := NewEmbeddedWallet(testLoader{bts: bts}, nil, proto.MainNetScheme)
+		w := NewEmbeddedWallet(testLoader{bts: bts}, nil, proto.TestNetScheme)
 		require.NoError(t, w.Load([]byte("pass")))
 		require.Equal(t, [][]byte{[]byte("seed")}, w.Seeds())
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		w := NewEmbeddedWallet(testLoader{bts: bts}, nil, proto.MainNetScheme)
+		w := NewEmbeddedWallet(testLoader{bts: bts}, nil, proto.TestNetScheme)
 		require.Errorf(t, w.Load([]byte("incorrect")), "invalid password")
 	})
 
 	t.Run("load error", func(t *testing.T) {
-		w := NewEmbeddedWallet(testLoader{bts: nil, err: errors.New("loaderr")}, nil, proto.MainNetScheme)
+		w := NewEmbeddedWallet(testLoader{bts: nil, err: errors.New("loaderr")}, nil, proto.TestNetScheme)
 		require.Errorf(t, w.Load(nil), "loaderr")
 	})
 }


### PR DESCRIPTION
As suggested in issue #270, I've changed many of MainNetScheme to TestNetScheme, most of the ones that just needed changing without any additional refactoring in a way that it doesn't break tests.

```
find . -type f -name "*_test.go"  | xargs grep "MainNet" |  wc -l
943
git checkout tests-testnet 
find . -type f -name "*_test.go"  | xargs grep "MainNet" |  wc -l
261
```
```
find . -type f -name "*_test.go"  | xargs grep "MainNetScheme" |  wc -l
145
git checkout master
find . -type f -name "*_test.go"  | xargs grep "MainNetScheme" |  wc -l
821
```