### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/grpc/server/accounts_api_test.go
+++ b/pkg/grpc/server/accounts_api_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,8 +17,7 @@ import (
 )
 
 func TestGetBalances(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	require.NoError(t, err)
@@ -29,15 +26,13 @@ func TestGetBalances(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err := conn.Close()
 		require.NoError(t, err)
 		err = st.Close()
 		require.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		require.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewAccountsApiClient(conn)
 	addr, err := proto.NewAddressFromString("3PAWwWa6GbwcJaFzwqXQN5KQm7H96Y7SHTQ")
@@ -67,7 +62,7 @@ func TestGetBalances(t *testing.T) {
 func TestGetActiveLeases(t *testing.T) {
 	genesisPath, err := globalPathFromLocal("testdata/genesis/lease_genesis.json")
 	require.NoError(t, err)
-	st, stateCloser := stateWithCustomGenesis(t, genesisPath)
+	st := stateWithCustomGenesis(t, genesisPath)
 	sets, err := st.BlockchainSettings()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -76,12 +71,11 @@ func TestGetActiveLeases(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err = conn.Close()
 		require.NoError(t, err)
-		stateCloser()
-	}()
+	})
 
 	cl := g.NewAccountsApiClient(conn)
 	addr, err := proto.NewAddressFromString("3Fv3jiLvLS4c4N1ZvSLac3HBGUzaHDMvjN1")
@@ -118,7 +112,7 @@ func TestGetActiveLeases(t *testing.T) {
 func TestResolveAlias(t *testing.T) {
 	genesisPath, err := globalPathFromLocal("testdata/genesis/alias_genesis.json")
 	require.NoError(t, err)
-	st, stateCloser := stateWithCustomGenesis(t, genesisPath)
+	st := stateWithCustomGenesis(t, genesisPath)
 	sets, err := st.BlockchainSettings()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -127,12 +121,11 @@ func TestResolveAlias(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err := conn.Close()
 		require.NoError(t, err)
-		stateCloser()
-	}()
+	})
 
 	cl := g.NewAccountsApiClient(conn)
 

--- a/pkg/grpc/server/assets_api_test.go
+++ b/pkg/grpc/server/assets_api_test.go
@@ -2,18 +2,19 @@ package server
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	g "github.com/wavesplatform/gowaves/pkg/grpc/generated/waves/node/grpc"
 	"github.com/wavesplatform/gowaves/pkg/proto"
 	protobuf "google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestGetInfo(t *testing.T) {
 	genesisPath, err := globalPathFromLocal("testdata/genesis/asset_issue_genesis.json")
 	assert.NoError(t, err)
-	st, stateCloser := stateWithCustomGenesis(t, genesisPath)
+	st := stateWithCustomGenesis(t, genesisPath)
 	sets, err := st.BlockchainSettings()
 	assert.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -22,11 +23,10 @@ func TestGetInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
-		stateCloser()
-	}()
+	})
 
 	cl := g.NewAssetsApiClient(conn)
 

--- a/pkg/grpc/server/blockchain_api_test.go
+++ b/pkg/grpc/server/blockchain_api_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +13,7 @@ import (
 )
 
 func TestGetBaseTarget(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	params.StoreExtendedApiData = true
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
@@ -27,14 +24,12 @@ func TestGetBaseTarget(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
 		err = st.Close()
 		assert.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		assert.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewBlockchainApiClient(conn)
 
@@ -56,8 +51,7 @@ func TestGetBaseTarget(t *testing.T) {
 }
 
 func TestGetCumulativeScore(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	assert.NoError(t, err)
@@ -67,14 +61,12 @@ func TestGetCumulativeScore(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
 		err = st.Close()
 		assert.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		assert.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewBlockchainApiClient(conn)
 

--- a/pkg/grpc/server/blocks_api_test.go
+++ b/pkg/grpc/server/blocks_api_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,8 +33,7 @@ func blockFromState(t *testing.T, height proto.Height, st state.StateInfo) *g.Bl
 }
 
 func TestGetBlock(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	assert.NoError(t, err)
@@ -46,14 +43,12 @@ func TestGetBlock(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
 		err = st.Close()
 		assert.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		assert.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewBlocksApiClient(conn)
 
@@ -93,8 +88,7 @@ func TestGetBlock(t *testing.T) {
 }
 
 func TestGetBlockRange(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	assert.NoError(t, err)
@@ -104,14 +98,12 @@ func TestGetBlockRange(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
 		err = st.Close()
 		assert.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		assert.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewBlocksApiClient(conn)
 
@@ -174,8 +166,7 @@ func TestGetBlockRange(t *testing.T) {
 }
 
 func TestGetCurrentHeight(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	assert.NoError(t, err)
@@ -185,14 +176,12 @@ func TestGetCurrentHeight(t *testing.T) {
 	assert.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		conn.Close()
 		err = st.Close()
 		assert.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		assert.NoError(t, err)
-	}()
+	})
 
 	cl := g.NewBlocksApiClient(conn)
 

--- a/pkg/grpc/server/transactions_api_test.go
+++ b/pkg/grpc/server/transactions_api_test.go
@@ -3,10 +3,8 @@ package server
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -29,7 +27,7 @@ import (
 func TestGetTransactions(t *testing.T) {
 	genesisPath, err := globalPathFromLocal("testdata/genesis/lease_genesis.json")
 	require.NoError(t, err)
-	st, stateCloser := stateWithCustomGenesis(t, genesisPath)
+	st := stateWithCustomGenesis(t, genesisPath)
 	sets, err := st.BlockchainSettings()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -38,12 +36,11 @@ func TestGetTransactions(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err := conn.Close()
 		require.NoError(t, err)
-		stateCloser()
-	}()
+	})
 
 	id, err := crypto.NewDigestFromBase58("ADXuoPsKMJ59HyLMGzLBbNQD8p2eJ93dciuBPJp3Qhx")
 	require.NoError(t, err)
@@ -114,8 +111,7 @@ func TestGetTransactions(t *testing.T) {
 }
 
 func TestGetStatuses(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	require.NoError(t, err)
@@ -126,15 +122,13 @@ func TestGetStatuses(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err := conn.Close()
 		require.NoError(t, err)
 		err = st.Close()
 		require.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		require.NoError(t, err)
-	}()
+	})
 
 	addr, err := proto.NewAddressFromString("3PAWwWa6GbwcJaFzwqXQN5KQm7H96Y7SHTQ")
 	require.NoError(t, err)
@@ -178,8 +172,7 @@ func TestGetStatuses(t *testing.T) {
 }
 
 func TestGetUnconfirmed(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	require.NoError(t, err)
@@ -190,15 +183,13 @@ func TestGetUnconfirmed(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err = conn.Close()
 		require.NoError(t, err)
 		err = st.Close()
 		require.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		require.NoError(t, err)
-	}()
+	})
 
 	addr, err := proto.NewAddressFromString("3PAWwWa6GbwcJaFzwqXQN5KQm7H96Y7SHTQ")
 	require.NoError(t, err)
@@ -277,8 +268,7 @@ func TestGetUnconfirmed(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	params := defaultStateParams()
 	st, err := state.NewState(dataDir, true, params, settings.MainNetSettings)
 	require.NoError(t, err)
@@ -289,15 +279,13 @@ func TestSign(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := connect(t, grpcTestAddr)
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		err = conn.Close()
 		require.NoError(t, err)
 		err = st.Close()
 		require.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		require.NoError(t, err)
-	}()
+	})
 
 	pk := keyPairs[0].Public
 

--- a/pkg/grpc/server/tx_filter_leases_test.go
+++ b/pkg/grpc/server/tx_filter_leases_test.go
@@ -13,7 +13,7 @@ import (
 func TestTxFilterLeases(t *testing.T) {
 	genesisPath, err := globalPathFromLocal("testdata/genesis/lease_genesis.json")
 	require.NoError(t, err)
-	st, stCloser := stateWithCustomGenesis(t, genesisPath)
+	st := stateWithCustomGenesis(t, genesisPath)
 	txId, err := crypto.NewDigestFromBase58("ADXuoPsKMJ59HyLMGzLBbNQD8p2eJ93dciuBPJp3Qhx")
 	require.NoError(t, err)
 	txId2, err := crypto.NewDigestFromBase58("ADXuoPsKMJ59HyLMGzLBbNQD7p2eJ93dciuBPJp3Qhx")
@@ -25,10 +25,6 @@ func TestTxFilterLeases(t *testing.T) {
 	require.NoError(t, err)
 	pk2, err := crypto.NewPublicKeyFromBase58("7rAoh3kPtsPQCTMVe8Bb39GKNX17bR5G57Ef66uwXfeT")
 	require.NoError(t, err)
-
-	defer func() {
-		stCloser()
-	}()
 
 	var tx proto.Transaction
 	req := &g.TransactionsRequest{Sender: addrBody}

--- a/pkg/keyvalue/bloom_filter_test.go
+++ b/pkg/keyvalue/bloom_filter_test.go
@@ -1,9 +1,7 @@
 package keyvalue
 
 import (
-	"io/ioutil"
 	"math/rand"
-	"os"
 	"path"
 	"testing"
 
@@ -33,11 +31,7 @@ func TestBloomFilter(t *testing.T) {
 }
 
 func TestSaveLoad(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "bloom")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 	cacheFile := path.Join(dir, "bloom_cache")
 
 	params := NewBloomFilterParams(n, falsePositiveProbability, NewStore(cacheFile))

--- a/pkg/keyvalue/leveldb_test.go
+++ b/pkg/keyvalue/leveldb_test.go
@@ -1,12 +1,9 @@
 package keyvalue
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,8 +14,7 @@ const (
 )
 
 func TestKeyVal(t *testing.T) {
-	dbDir, err := ioutil.TempDir(os.TempDir(), "dbDir0")
-	require.NoError(t, err)
+	dbDir := t.TempDir()
 	params := KeyValParams{
 		CacheParams:         CacheParams{cacheSize},
 		BloomFilterParams:   BloomFilterParams{n, falsePositiveProbability, NoOpStore{}, false},
@@ -29,12 +25,10 @@ func TestKeyVal(t *testing.T) {
 	kv, err := NewKeyVal(dbDir, params)
 	assert.NoError(t, err, "NewKeyVal() failed")
 
-	defer func() {
+	t.Cleanup(func() {
 		err = kv.Close()
 		assert.NoError(t, err, "Close() failed")
-		err = os.RemoveAll(dbDir)
-		assert.NoError(t, err, "os.RemoveAll() failed")
-	}()
+	})
 
 	// Test direct DB operations.
 	keyPrefix := []byte("sampleKey")

--- a/pkg/node/peer_manager/storage/cbor_test.go
+++ b/pkg/node/peer_manager/storage/cbor_test.go
@@ -90,13 +90,7 @@ type binaryStorageCborSuite struct {
 }
 
 func (s *binaryStorageCborSuite) SetupTest() {
-	tmpdir, err := ioutil.TempDir("", "peers_storage_test_suite_*")
-	require.NoError(s.T(), err)
-	defer func() {
-		if err != nil {
-			assert.NoError(s.T(), os.Remove(tmpdir))
-		}
-	}()
+	tmpdir := s.T().TempDir()
 	now := time.Now()
 	storage, err := newCBORStorageInDir(tmpdir, now, peersStorageCurrentVersion)
 	require.NoError(s.T(), err)
@@ -106,9 +100,7 @@ func (s *binaryStorageCborSuite) SetupTest() {
 }
 
 func (s *binaryStorageCborSuite) TearDownTest() {
-	tmpdir := s.storage.storageDir
 	s.storage = nil
-	require.NoError(s.T(), os.RemoveAll(tmpdir))
 }
 
 func TestBinaryStorageCborTestSuite(t *testing.T) {

--- a/pkg/state/address_transactions_test.go
+++ b/pkg/state/address_transactions_test.go
@@ -2,8 +2,6 @@ package state
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,17 +12,14 @@ import (
 )
 
 func testIterImpl(t *testing.T, params StateParams) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	st, err := NewState(dataDir, true, params, settings.MainNetSettings)
 	require.NoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		err = st.Close()
 		require.NoError(t, err)
-		err = os.RemoveAll(dataDir)
-		require.NoError(t, err)
-	}()
+	})
 
 	blockHeight := proto.Height(9900)
 	blocks, err := ReadMainnetBlocksToHeight(blockHeight)
@@ -117,16 +112,15 @@ func TestTransactionsByAddrIteratorOptimized(t *testing.T) {
 func TestAddrTransactionsIdempotent(t *testing.T) {
 	stor, path, err := createStorageObjects(true)
 	require.NoError(t, err)
-	atxDir, err := ioutil.TempDir(os.TempDir(), "atx")
-	require.NoError(t, err)
+	atxDir := t.TempDir()
 	path = append(path, atxDir)
 
-	defer func() {
+	t.Cleanup(func() {
 		stor.close(t)
 
 		err = common.CleanTemporaryDirs(path)
 		require.NoError(t, err, "failed to clean test data dirs")
-	}()
+	})
 
 	params := &addressTransactionsParams{
 		dir:                 atxDir,
@@ -175,16 +169,15 @@ func TestAddrTransactionsIdempotent(t *testing.T) {
 func TestFailedTransaction(t *testing.T) {
 	stor, path, err := createStorageObjects(true)
 	require.NoError(t, err)
-	atxDir, err := ioutil.TempDir(os.TempDir(), "atx")
-	require.NoError(t, err)
+	atxDir := t.TempDir()
 	path = append(path, atxDir)
 
-	defer func() {
+	t.Cleanup(func() {
 		stor.close(t)
 
 		err = common.CleanTemporaryDirs(path)
 		require.NoError(t, err, "failed to clean test data dirs")
-	}()
+	})
 
 	params := &addressTransactionsParams{
 		dir:                 atxDir,

--- a/pkg/state/headers_validation_test.go
+++ b/pkg/state/headers_validation_test.go
@@ -2,9 +2,7 @@ package state
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/rand"
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -84,23 +82,17 @@ func TestHeadersValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can not read blocks from blockchain file: %v\n", err)
 	}
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir for data: %v\n", err)
-	}
+	dataDir := t.TempDir()
 	st, err := NewState(dataDir, true, stateParams(), settings.MainNetSettings)
 	if err != nil {
 		t.Fatalf("NewState(): %v\n", err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		if err := st.Close(); err != nil {
 			t.Fatalf("Failed to close state: %v\n", err)
 		}
-		if err := os.RemoveAll(dataDir); err != nil {
-			t.Fatalf("Failed to clean data dirs: %v\n", err)
-		}
-	}()
+	})
 
 	err = applyBlocks(t, blocks, st)
 	assert.NoError(t, err, "failed to apply correct blocks")

--- a/pkg/state/invoke_applier_test.go
+++ b/pkg/state/invoke_applier_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -34,17 +33,15 @@ type invokeApplierTestObjects struct {
 	state *stateManager
 }
 
-func createInvokeApplierTestObjects(t *testing.T) (*invokeApplierTestObjects, string) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "dataDir")
-	assert.NoError(t, err, "failed to create dir for test state")
-	state, err := newStateManager(dataDir, true, DefaultTestingStateParams(), settings.MainNetSettings)
+func createInvokeApplierTestObjects(t *testing.T) *invokeApplierTestObjects {
+	state, err := newStateManager(t.TempDir(), true, DefaultTestingStateParams(), settings.MainNetSettings)
 	assert.NoError(t, err, "newStateManager() failed")
 	err = state.stateDB.addBlock(blockID0)
 	assert.NoError(t, err)
 	to := &invokeApplierTestObjects{state}
 	to.activateFeature(t, int16(settings.SmartAccounts))
 	to.activateFeature(t, int16(settings.Ride4DApps))
-	return to, dataDir
+	return to
 }
 
 func (to *invokeApplierTestObjects) fallibleValidationParams(t *testing.T) *fallibleValidationParams {
@@ -311,14 +308,12 @@ func verify() = {
 */
 
 func TestApplyInvokeScriptPaymentsAndData(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		assert.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		assert.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "dapp.base64", testGlobal.recipientInfo)
@@ -358,14 +353,12 @@ func TestApplyInvokeScriptPaymentsAndData(t *testing.T) {
 }
 
 func TestApplyInvokeScriptTransfers(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		assert.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		assert.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "dapp.base64", testGlobal.recipientInfo)
@@ -424,14 +417,12 @@ func TestApplyInvokeScriptTransfers(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithIssues(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride4_asset.base64", testGlobal.recipientInfo)
@@ -463,14 +454,12 @@ func TestApplyInvokeScriptWithIssues(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithIssuesThenReissue(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride4_asset.base64", testGlobal.recipientInfo)
@@ -517,14 +506,12 @@ func TestApplyInvokeScriptWithIssuesThenReissue(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithIssuesThenReissueThenBurn(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride4_asset.base64", testGlobal.recipientInfo)
@@ -586,14 +573,12 @@ func TestApplyInvokeScriptWithIssuesThenReissueThenBurn(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithIssuesThenReissueThenFailOnReissue(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride4_asset.base64", testGlobal.recipientInfo)
@@ -646,14 +631,12 @@ func TestApplyInvokeScriptWithIssuesThenReissueThenFailOnReissue(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithIssuesThenFailOnBurnTooMuch(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride4_asset.base64", testGlobal.recipientInfo)
@@ -709,14 +692,12 @@ func TestApplyInvokeScriptWithIssuesThenFailOnBurnTooMuch(t *testing.T) {
 
 // TestFailedApplyInvokeScript in this test we
 func TestFailedApplyInvokeScript(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	info.acceptFailed = true
@@ -780,14 +761,12 @@ func TestFailedApplyInvokeScript(t *testing.T) {
 }
 
 func TestFailedInvokeApplicationComplexity(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	infoBefore := to.fallibleValidationParams(t)
 	infoBefore.acceptFailed = true
@@ -875,16 +854,14 @@ func TestFailedInvokeApplicationComplexity(t *testing.T) {
 }
 
 func TestFailedInvokeApplicationComplexityAfterRideV6(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 	to.activateFeature(t, int16(settings.RideV5))
 	to.activateFeature(t, int16(settings.RideV6))
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	info.acceptFailed = true
@@ -1005,15 +982,13 @@ func cancel(id: ByteVector) = ([LeaseCancel(id)], unit)
 */
 
 func TestApplyInvokeScriptWithLease(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 	to.activateFeature(t, int16(settings.RideV5))
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride5_leasing.base64", testGlobal.recipientInfo)
@@ -1053,15 +1028,13 @@ func TestApplyInvokeScriptWithLease(t *testing.T) {
 }
 
 func TestApplyInvokeScriptWithLeaseAndLeaseCancel(t *testing.T) {
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 	to.activateFeature(t, int16(settings.RideV5))
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	to.setDApp(t, "ride5_leasing.base64", testGlobal.recipientInfo)
@@ -1167,14 +1140,12 @@ func TestFailRejectOnThrow(t *testing.T) {
 		}
 	*/
 
-	to, path := createInvokeApplierTestObjects(t)
+	to := createInvokeApplierTestObjects(t)
 
-	defer func() {
+	t.Cleanup(func() {
 		err := to.state.Close()
 		require.NoError(t, err, "state.Close() failed")
-		err = os.RemoveAll(path)
-		require.NoError(t, err, "failed to remove test data dir")
-	}()
+	})
 
 	info := to.fallibleValidationParams(t)
 	info.acceptFailed = true


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```