### PR TITLE
Add blacklisting

### DIFF
--- a/itests/config/config.go
+++ b/itests/config/config.go
@@ -85,11 +85,11 @@ func CreateFileConfigs(enableScalaMining bool) (ConfigPaths, TestConfig, error) 
 	cfg.ScalaOpts.EnableMining = enableScalaMining
 	scalaPath, err := CreateScalaNodeConfig(cfg)
 	if err != nil {
-		return ConfigPaths{}, TestConfig{}, errors.Wrap(err, "failed to create go-node config")
+		return ConfigPaths{}, TestConfig{}, errors.Wrap(err, "failed to create scala-node config")
 	}
 	goPath, err := CreateGoNodeConfig(cfg)
 	if err != nil {
-		return ConfigPaths{}, TestConfig{}, errors.Wrap(err, "failed to create scala-node config")
+		return ConfigPaths{}, TestConfig{}, errors.Wrap(err, "failed to create go-node config")
 	}
 	return ConfigPaths{ScalaConfigPath: scalaPath, GoConfigPath: goPath}, TestConfig{Accounts: acc}, nil
 }

--- a/pkg/api/app_peers.go
+++ b/pkg/api/app_peers.go
@@ -143,7 +143,7 @@ func (a *App) PeersSuspended() []SuspendedPeerInfo {
 	for _, p := range suspended {
 		out = append(out, SuspendedPeerInfo{
 			Hostname:  "/" + p.IP.String(),
-			Timestamp: p.SuspendTimestampMillis,
+			Timestamp: p.RestrictTimestampMillis,
 			Reason:    p.Reason,
 		})
 	}

--- a/pkg/api/app_peers.go
+++ b/pkg/api/app_peers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -155,7 +156,7 @@ func (a *App) PeersSuspended() []RestrictedPeerInfo {
 	return out
 }
 
-func (a *App) PeersBlackList() []RestrictedPeerInfo {
+func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 	blackList := a.peers.BlackList()
 
 	out := make([]RestrictedPeerInfo, 0, len(blackList))
@@ -168,6 +169,20 @@ func (a *App) PeersBlackList() []RestrictedPeerInfo {
 	}
 
 	return out
+}
+
+type PeersClearBlackListResponse struct {
+	Result string `json:"result"`
+}
+
+func (a *App) PeersClearBlackList() PeersClearBlackListResponse {
+	resp := PeersClearBlackListResponse{}
+	if err := a.peers.ClearBlackList(); err != nil {
+		resp.Result = fmt.Sprintf("failed to clear blacklist: %s", err.Error())
+	} else {
+		resp.Result = "blacklist cleared"
+	}
+	return resp
 }
 
 type PeersSpawnedResponse struct {

--- a/pkg/api/app_peers_test.go
+++ b/pkg/api/app_peers_test.go
@@ -1,12 +1,13 @@
 package api
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/wavesplatform/gowaves/pkg/node/peer_manager/storage"
-	"github.com/wavesplatform/gowaves/pkg/proto"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wavesplatform/gowaves/pkg/node/peer_manager/storage"
+	"github.com/wavesplatform/gowaves/pkg/proto"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -39,18 +40,18 @@ func TestApp_PeersSuspended(t *testing.T) {
 	now := time.Now()
 
 	ips := []string{"13.3.4.1", "5.3.6.7"}
-	testData := []storage.SuspendedPeer{
+	testData := []storage.RestrictedPeer{
 		{
-			IP:                     storage.IPFromString(ips[0]),
-			SuspendTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,
-			SuspendDuration:        time.Minute,
-			Reason:                 "some reason #1",
+			IP:                      storage.IPFromString(ips[0]),
+			RestrictTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,
+			RestrictDuration:        time.Minute,
+			Reason:                  "some reason #1",
 		},
 		{
-			IP:                     storage.IPFromString(ips[1]),
-			SuspendTimestampMillis: now.Add(2*time.Minute).UnixNano() / 1_000_000,
-			SuspendDuration:        time.Minute,
-			Reason:                 "some reason #2",
+			IP:                      storage.IPFromString(ips[1]),
+			RestrictTimestampMillis: now.Add(2*time.Minute).UnixNano() / 1_000_000,
+			RestrictDuration:        time.Minute,
+			Reason:                  "some reason #2",
 		},
 	}
 
@@ -65,7 +66,7 @@ func TestApp_PeersSuspended(t *testing.T) {
 		p := testData[i]
 		expected := SuspendedPeerInfo{
 			Hostname:  "/" + ips[i],
-			Timestamp: p.SuspendTimestampMillis,
+			Timestamp: p.RestrictTimestampMillis,
 			Reason:    p.Reason,
 		}
 		assert.Equal(t, expected, actual)

--- a/pkg/api/app_peers_test.go
+++ b/pkg/api/app_peers_test.go
@@ -43,13 +43,13 @@ func TestApp_PeersSuspended(t *testing.T) {
 	testData := []storage.SuspendedPeer{
 		{
 			IP:                      storage.IPFromString(ips[0]),
-			RestrictTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,
+			RestrictTimestampMillis: now.Add(time.Minute).UnixMilli(),
 			RestrictDuration:        time.Minute,
 			Reason:                  "some reason #1",
 		},
 		{
 			IP:                      storage.IPFromString(ips[1]),
-			RestrictTimestampMillis: now.Add(2*time.Minute).UnixNano() / 1_000_000,
+			RestrictTimestampMillis: now.Add(2 * time.Minute).UnixMilli(),
 			RestrictDuration:        time.Minute,
 			Reason:                  "some reason #2",
 		},
@@ -85,13 +85,13 @@ func TestApp_PeersBlackList(t *testing.T) {
 	testData := []storage.BlackListedPeer{
 		{
 			IP:                      storage.IPFromString(ips[0]),
-			RestrictTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,
+			RestrictTimestampMillis: now.Add(time.Minute).UnixMilli(),
 			RestrictDuration:        time.Minute,
 			Reason:                  "some reason #1",
 		},
 		{
 			IP:                      storage.IPFromString(ips[1]),
-			RestrictTimestampMillis: now.Add(2*time.Minute).UnixNano() / 1_000_000,
+			RestrictTimestampMillis: now.Add(2 * time.Minute).UnixMilli(),
 			RestrictDuration:        time.Minute,
 			Reason:                  "some reason #2",
 		},
@@ -102,7 +102,7 @@ func TestApp_PeersBlackList(t *testing.T) {
 	app, err := NewApp("key", nil, services.Services{Peers: peerManager})
 	require.NoError(t, err)
 
-	blackList := app.PeersBlackList()
+	blackList := app.PeersBlackListed()
 
 	for i, actual := range blackList {
 		p := testData[i]

--- a/pkg/api/app_peers_test.go
+++ b/pkg/api/app_peers_test.go
@@ -40,7 +40,7 @@ func TestApp_PeersSuspended(t *testing.T) {
 	now := time.Now()
 
 	ips := []string{"13.3.4.1", "5.3.6.7"}
-	testData := []storage.RestrictedPeer{
+	testData := []storage.SuspendedPeer{
 		{
 			IP:                      storage.IPFromString(ips[0]),
 			RestrictTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,
@@ -82,7 +82,7 @@ func TestApp_PeersBlackList(t *testing.T) {
 	now := time.Now()
 
 	ips := []string{"13.3.4.1", "5.3.6.7"}
-	testData := []storage.RestrictedPeer{
+	testData := []storage.BlackListedPeer{
 		{
 			IP:                      storage.IPFromString(ips[0]),
 			RestrictTimestampMillis: now.Add(time.Minute).UnixNano() / 1_000_000,

--- a/pkg/api/node_api.go
+++ b/pkg/api/node_api.go
@@ -373,10 +373,18 @@ func (a *NodeApi) PeersSuspended(w http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func (a *NodeApi) PeersBlackList(w http.ResponseWriter, _ *http.Request) error {
-	rs := a.app.PeersBlackList()
+func (a *NodeApi) PeersBlackListed(w http.ResponseWriter, _ *http.Request) error {
+	rs := a.app.PeersBlackListed()
 	if err := trySendJson(w, rs); err != nil {
-		return errors.Wrap(err, "PeersBlackList")
+		return errors.Wrap(err, "PeersBlackListed")
+	}
+	return nil
+}
+
+func (a *NodeApi) PeersClearBlackList(w http.ResponseWriter, _ *http.Request) error {
+	rs := a.app.PeersClearBlackList()
+	if err := trySendJson(w, rs); err != nil {
+		return errors.Wrap(err, "PeersBlackListed")
 	}
 	return nil
 }

--- a/pkg/api/node_api.go
+++ b/pkg/api/node_api.go
@@ -373,6 +373,14 @@ func (a *NodeApi) PeersSuspended(w http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
+func (a *NodeApi) PeersBlackList(w http.ResponseWriter, _ *http.Request) error {
+	rs := a.app.PeersBlackList()
+	if err := trySendJson(w, rs); err != nil {
+		return errors.Wrap(err, "PeersBlackList")
+	}
+	return nil
+}
+
 func (a *NodeApi) BlocksGenerators(w http.ResponseWriter, _ *http.Request) error {
 	rs, err := a.app.BlocksGenerators()
 	if err != nil {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -116,11 +116,12 @@ func (a *NodeApi) routes(opts *RunOptions) (chi.Router, error) {
 			r.Get("/all", wrapper(a.PeersAll))
 			r.Get("/connected", wrapper(a.PeersConnected))
 			r.Get("/suspended", wrapper(a.PeersSuspended))
-			r.Get("/blackList", wrapper(a.PeersBlackList))
+			r.Get("/blacklisted", wrapper(a.PeersBlackListed))
 
 			rAuth := r.With(checkAuthMiddleware)
 
 			rAuth.Post("/connect", wrapper(a.PeersConnect))
+			rAuth.Post("/clearblacklist", wrapper(a.PeersClearBlackList))
 		})
 
 		r.Route("/debug", func(r chi.Router) {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -116,6 +116,7 @@ func (a *NodeApi) routes(opts *RunOptions) (chi.Router, error) {
 			r.Get("/all", wrapper(a.PeersAll))
 			r.Get("/connected", wrapper(a.PeersConnected))
 			r.Get("/suspended", wrapper(a.PeersSuspended))
+			r.Get("/blackList", wrapper(a.PeersBlackList))
 
 			rAuth := r.With(checkAuthMiddleware)
 

--- a/pkg/mock/peer_manager.go
+++ b/pkg/mock/peer_manager.go
@@ -39,6 +39,18 @@ func (m *MockPeerManager) EXPECT() *MockPeerManagerMockRecorder {
 	return m.recorder
 }
 
+// AddToBlackList mocks base method.
+func (m *MockPeerManager) AddToBlackList(peer peer.Peer, blockTime time.Time, reason string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddToBlackList", peer, blockTime, reason)
+}
+
+// AddToBlackList indicates an expected call of AddToBlackList.
+func (mr *MockPeerManagerMockRecorder) AddToBlackList(peer, blockTime, reason interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToBlackList", reflect.TypeOf((*MockPeerManager)(nil).AddToBlackList), peer, blockTime, reason)
+}
+
 // AskPeers mocks base method.
 func (m *MockPeerManager) AskPeers() {
 	m.ctrl.T.Helper()
@@ -49,6 +61,20 @@ func (m *MockPeerManager) AskPeers() {
 func (mr *MockPeerManagerMockRecorder) AskPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AskPeers", reflect.TypeOf((*MockPeerManager)(nil).AskPeers))
+}
+
+// BlackList mocks base method.
+func (m *MockPeerManager) BlackList() []storage.BlackListedPeer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlackList")
+	ret0, _ := ret[0].([]storage.BlackListedPeer)
+	return ret0
+}
+
+// BlackList indicates an expected call of BlackList.
+func (mr *MockPeerManagerMockRecorder) BlackList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlackList", reflect.TypeOf((*MockPeerManager)(nil).BlackList))
 }
 
 // Close mocks base method.

--- a/pkg/mock/peer_manager.go
+++ b/pkg/mock/peer_manager.go
@@ -77,6 +77,20 @@ func (mr *MockPeerManagerMockRecorder) BlackList() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlackList", reflect.TypeOf((*MockPeerManager)(nil).BlackList))
 }
 
+// ClearBlackList mocks base method.
+func (m *MockPeerManager) ClearBlackList() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearBlackList")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearBlackList indicates an expected call of ClearBlackList.
+func (mr *MockPeerManagerMockRecorder) ClearBlackList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearBlackList", reflect.TypeOf((*MockPeerManager)(nil).ClearBlackList))
+}
+
 // Close mocks base method.
 func (m *MockPeerManager) Close() {
 	m.ctrl.T.Helper()

--- a/pkg/mock/peer_storage.go
+++ b/pkg/mock/peer_storage.go
@@ -120,7 +120,7 @@ func (mr *MockPeerStorageMockRecorder) DeleteKnown(known interface{}) *gomock.Ca
 }
 
 // DeleteSuspendedByIP mocks base method.
-func (m *MockPeerStorage) DeleteSuspendedByIP(suspended []storage.RestrictedPeer) error {
+func (m *MockPeerStorage) DeleteSuspendedByIP(suspended []storage.SuspendedPeer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSuspendedByIP", suspended)
 	ret0, _ := ret[0].(error)

--- a/pkg/mock/peer_storage.go
+++ b/pkg/mock/peer_storage.go
@@ -63,6 +63,48 @@ func (mr *MockPeerStorageMockRecorder) AddSuspended(suspended interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSuspended", reflect.TypeOf((*MockPeerStorage)(nil).AddSuspended), suspended)
 }
 
+// AddToBlackList mocks base method.
+func (m *MockPeerStorage) AddToBlackList(blackListed []storage.BlackListedPeer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddToBlackList", blackListed)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddToBlackList indicates an expected call of AddToBlackList.
+func (mr *MockPeerStorageMockRecorder) AddToBlackList(blackListed interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToBlackList", reflect.TypeOf((*MockPeerStorage)(nil).AddToBlackList), blackListed)
+}
+
+// BlackList mocks base method.
+func (m *MockPeerStorage) BlackList(now time.Time) []storage.BlackListedPeer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlackList", now)
+	ret0, _ := ret[0].([]storage.BlackListedPeer)
+	return ret0
+}
+
+// BlackList indicates an expected call of BlackList.
+func (mr *MockPeerStorageMockRecorder) BlackList(now interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlackList", reflect.TypeOf((*MockPeerStorage)(nil).BlackList), now)
+}
+
+// DeleteBlackListedByIP mocks base method.
+func (m *MockPeerStorage) DeleteBlackListedByIP(blackListed []storage.BlackListedPeer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBlackListedByIP", blackListed)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBlackListedByIP indicates an expected call of DeleteBlackListedByIP.
+func (mr *MockPeerStorageMockRecorder) DeleteBlackListedByIP(blackListed interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBlackListedByIP", reflect.TypeOf((*MockPeerStorage)(nil).DeleteBlackListedByIP), blackListed)
+}
+
 // DeleteKnown mocks base method.
 func (m *MockPeerStorage) DeleteKnown(known []storage.KnownPeer) error {
 	m.ctrl.T.Helper()
@@ -78,7 +120,7 @@ func (mr *MockPeerStorageMockRecorder) DeleteKnown(known interface{}) *gomock.Ca
 }
 
 // DeleteSuspendedByIP mocks base method.
-func (m *MockPeerStorage) DeleteSuspendedByIP(suspended []storage.SuspendedPeer) error {
+func (m *MockPeerStorage) DeleteSuspendedByIP(suspended []storage.RestrictedPeer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSuspendedByIP", suspended)
 	ret0, _ := ret[0].(error)
@@ -89,6 +131,20 @@ func (m *MockPeerStorage) DeleteSuspendedByIP(suspended []storage.SuspendedPeer)
 func (mr *MockPeerStorageMockRecorder) DeleteSuspendedByIP(suspended interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSuspendedByIP", reflect.TypeOf((*MockPeerStorage)(nil).DeleteSuspendedByIP), suspended)
+}
+
+// DropBlackList mocks base method.
+func (m *MockPeerStorage) DropBlackList() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DropBlackList")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DropBlackList indicates an expected call of DropBlackList.
+func (mr *MockPeerStorageMockRecorder) DropBlackList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropBlackList", reflect.TypeOf((*MockPeerStorage)(nil).DropBlackList))
 }
 
 // DropKnown mocks base method.
@@ -133,6 +189,34 @@ func (mr *MockPeerStorageMockRecorder) DropSuspended() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropSuspended", reflect.TypeOf((*MockPeerStorage)(nil).DropSuspended))
 }
 
+// IsBlackListedIP mocks base method.
+func (m *MockPeerStorage) IsBlackListedIP(ip storage.IP, now time.Time) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsBlackListedIP", ip, now)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsBlackListedIP indicates an expected call of IsBlackListedIP.
+func (mr *MockPeerStorageMockRecorder) IsBlackListedIP(ip, now interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlackListedIP", reflect.TypeOf((*MockPeerStorage)(nil).IsBlackListedIP), ip, now)
+}
+
+// IsBlackListedIPs mocks base method.
+func (m *MockPeerStorage) IsBlackListedIPs(ips []storage.IP, now time.Time) []bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsBlackListedIPs", ips, now)
+	ret0, _ := ret[0].([]bool)
+	return ret0
+}
+
+// IsBlackListedIPs indicates an expected call of IsBlackListedIPs.
+func (mr *MockPeerStorageMockRecorder) IsBlackListedIPs(ips, now interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlackListedIPs", reflect.TypeOf((*MockPeerStorage)(nil).IsBlackListedIPs), ips, now)
+}
+
 // IsSuspendedIP mocks base method.
 func (m *MockPeerStorage) IsSuspendedIP(ip storage.IP, now time.Time) bool {
 	m.ctrl.T.Helper()
@@ -173,6 +257,20 @@ func (m *MockPeerStorage) Known(limit int) []storage.KnownPeer {
 func (mr *MockPeerStorageMockRecorder) Known(limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Known", reflect.TypeOf((*MockPeerStorage)(nil).Known), limit)
+}
+
+// RefreshBlackList mocks base method.
+func (m *MockPeerStorage) RefreshBlackList(now time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshBlackList", now)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshBlackList indicates an expected call of RefreshBlackList.
+func (mr *MockPeerStorageMockRecorder) RefreshBlackList(now interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshBlackList", reflect.TypeOf((*MockPeerStorage)(nil).RefreshBlackList), now)
 }
 
 // RefreshSuspended mocks base method.

--- a/pkg/node/peer_manager/peer_manager.go
+++ b/pkg/node/peer_manager/peer_manager.go
@@ -389,15 +389,13 @@ func (a *PeerManagerImpl) Disconnect(p peer.Peer) {
 }
 
 func (a *PeerManagerImpl) Run(ctx context.Context) {
+	ticker := time.NewTicker(clearRestrictedPeersInterval)
+	defer ticker.Stop()
 	for {
-		timer := time.NewTimer(clearRestrictedPeersInterval)
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
 			return
-		case <-timer.C:
+		case <-ticker.C:
 			a.clearRestrictedPeers(time.Now())
 		}
 	}

--- a/pkg/node/peer_manager/peer_manager.go
+++ b/pkg/node/peer_manager/peer_manager.go
@@ -2,6 +2,7 @@ package peer_manager
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"net"
 	"sync"
@@ -471,11 +472,13 @@ func (a *PeerManagerImpl) blackListed(p peer.Peer, now time.Time) bool {
 }
 
 func (a *PeerManagerImpl) restrict(p peer.Peer, now time.Time, reason string) {
-	switch p.Direction() {
+	switch d := p.Direction(); d {
 	case peer.Incoming:
 		a.AddToBlackList(p, now, reason)
 	case peer.Outgoing:
 		a.Suspend(p, now, reason)
+	default:
+		panic(fmt.Sprintf("BUG, CREATE REPORT: can't restrict peer because of unexpected peer direction (%d)", d))
 	}
 }
 

--- a/pkg/node/peer_manager/peer_storage.go
+++ b/pkg/node/peer_manager/peer_storage.go
@@ -23,7 +23,7 @@ type PeerStorage interface {
 	BlackList(now time.Time) []storage.BlackListedPeer
 	AddToBlackList(blackListed []storage.BlackListedPeer) error
 	IsBlackListedIP(ip storage.IP, now time.Time) bool
-	IsBlackListedIPs(ip storage.IP, now time.Time) []bool
+	IsBlackListedIPs(ips []storage.IP, now time.Time) []bool
 	DeleteBlackListedByIP(blackListed []storage.BlackListedPeer) error
 	RefreshBlackList(now time.Time) error
 	DropBlackList() error

--- a/pkg/node/peer_manager/peer_storage.go
+++ b/pkg/node/peer_manager/peer_storage.go
@@ -16,9 +16,17 @@ type PeerStorage interface {
 	AddSuspended(suspended []storage.SuspendedPeer) error
 	IsSuspendedIP(ip storage.IP, now time.Time) bool
 	IsSuspendedIPs(ips []storage.IP, now time.Time) []bool
-	DeleteSuspendedByIP(suspended []storage.SuspendedPeer) error
+	DeleteSuspendedByIP(suspended []storage.RestrictedPeer) error
 	RefreshSuspended(now time.Time) error
 	DropSuspended() error
+
+	BlackList(now time.Time) []storage.BlackListedPeer
+	AddToBlackList(blackListed []storage.BlackListedPeer) error
+	IsBlackListedIP(ip storage.IP, now time.Time) bool
+	IsBlackListedIPs(ip storage.IP, now time.Time) []bool
+	DeleteBlackListedByIP(blackListed []storage.BlackListedPeer) error
+	RefreshBlackList(now time.Time) error
+	DropBlackList() error
 
 	DropStorage() error
 }

--- a/pkg/node/peer_manager/peer_storage.go
+++ b/pkg/node/peer_manager/peer_storage.go
@@ -16,7 +16,7 @@ type PeerStorage interface {
 	AddSuspended(suspended []storage.SuspendedPeer) error
 	IsSuspendedIP(ip storage.IP, now time.Time) bool
 	IsSuspendedIPs(ips []storage.IP, now time.Time) []bool
-	DeleteSuspendedByIP(suspended []storage.RestrictedPeer) error
+	DeleteSuspendedByIP(suspended []storage.SuspendedPeer) error
 	RefreshSuspended(now time.Time) error
 	DropSuspended() error
 

--- a/pkg/node/peer_manager/peer_storage_test.go
+++ b/pkg/node/peer_manager/peer_storage_test.go
@@ -27,11 +27,11 @@ func TestPeerManagerImpl_Suspend(t *testing.T) {
 	)
 
 	peerStorage := mock.NewMockPeerStorage(ctrl)
-	peerStorage.EXPECT().AddSuspended([]storage.SuspendedPeer{{
-		IP:                     storage.IpFromIpPort(tcpAddr.ToIpPort()),
-		SuspendTimestampMillis: now.UnixMilli(),
-		SuspendDuration:        suspendDuration,
-		Reason:                 reason,
+	peerStorage.EXPECT().AddSuspended([]storage.RestrictedPeer{{
+		IP:                      storage.IpFromIpPort(tcpAddr.ToIpPort()),
+		RestrictTimestampMillis: now.UnixMilli(),
+		RestrictDuration:        suspendDuration,
+		Reason:                  reason,
 	}})
 
 	manager := PeerManagerImpl{

--- a/pkg/node/peer_manager/peer_storage_test.go
+++ b/pkg/node/peer_manager/peer_storage_test.go
@@ -27,7 +27,7 @@ func TestPeerManagerImpl_Suspend(t *testing.T) {
 	)
 
 	peerStorage := mock.NewMockPeerStorage(ctrl)
-	peerStorage.EXPECT().AddSuspended([]storage.RestrictedPeer{{
+	peerStorage.EXPECT().AddSuspended([]storage.SuspendedPeer{{
 		IP:                      storage.IpFromIpPort(tcpAddr.ToIpPort()),
 		RestrictTimestampMillis: now.UnixMilli(),
 		RestrictDuration:        suspendDuration,

--- a/pkg/node/peer_manager/storage/cbor.go
+++ b/pkg/node/peer_manager/storage/cbor.go
@@ -49,6 +49,17 @@ func (bs *CBORStorage) restrictedPeersByType(restrictedID restrictedPeersID) *re
 	}
 }
 
+func (bs *CBORStorage) clearRestrictedPeersByType(restrictedID restrictedPeersID) {
+	switch restrictedID {
+	case suspendedPeersID:
+		bs.suspended = restrictedPeers{}
+	case blackListedPeersID:
+		bs.blackList = restrictedPeers{}
+	default:
+		panic(fmt.Sprintf("unexpected restrictedPeersID (%d)", restrictedID))
+	}
+}
+
 func NewCBORStorage(baseDir string, now time.Time) (*CBORStorage, error) {
 	storageDir := filepath.Join(baseDir, peersStorageDir)
 	return newCBORStorageInDir(storageDir, now, peersStorageCurrentVersion)
@@ -479,8 +490,8 @@ func (bs *CBORStorage) unsafeDropRestricted(restrictedID restrictedPeersID) erro
 	if err := os.Truncate(bs.restrictedFilePathByID(restrictedID), 0); err != nil {
 		return errors.Wrapf(err, "failed to drop suspended storage file %q", bs.suspendedFilePath)
 	}
-	// Clear map
-	*bs.restrictedPeersByType(restrictedID) = restrictedPeers{}
+	// Clear chosen restrictedPeers map
+	bs.clearRestrictedPeersByType(restrictedID)
 	return nil
 }
 

--- a/pkg/node/peer_manager/storage/cbor.go
+++ b/pkg/node/peer_manager/storage/cbor.go
@@ -444,7 +444,7 @@ func (bs *CBORStorage) restrictedFilePathByID(restrictedID restrictedPeersID) st
 	case blackListedPeersID:
 		return bs.blackListFilePath
 	default:
-		panic("unknown restricted id")
+		panic(fmt.Sprintf("unexpected restrictedPeersID (%d)", restrictedID))
 	}
 }
 
@@ -455,7 +455,7 @@ func restrictedNameByID(restrictedID restrictedPeersID) string {
 	case blackListedPeersID:
 		return "blackList"
 	default:
-		panic("unknown restricted id")
+		panic(fmt.Sprintf("unexpected restrictedPeersID (%d)", restrictedID))
 	}
 }
 

--- a/pkg/node/peer_manager/storage/cbor.go
+++ b/pkg/node/peer_manager/storage/cbor.go
@@ -193,11 +193,11 @@ func (bs *CBORStorage) DropKnown() error {
 	return bs.unsafeDropKnown()
 }
 
-func (bs *CBORStorage) restricted(now time.Time, restrictedID restrictedPeersID) []RestrictedPeer {
+func (bs *CBORStorage) restricted(now time.Time, restrictedID restrictedPeersID) []restrictedPeer {
 	bs.rwMutex.RLock()
 	defer bs.rwMutex.RUnlock()
 
-	restricted := make([]RestrictedPeer, 0, len(*bs.restrictedPeersByType(restrictedID)))
+	restricted := make([]restrictedPeer, 0, len(*bs.restrictedPeersByType(restrictedID)))
 	for _, s := range *bs.restrictedPeersByType(restrictedID) {
 		if s.IsRestricted(now) {
 			restricted = append(restricted, s)
@@ -215,7 +215,7 @@ func (bs *CBORStorage) AddSuspended(suspended []SuspendedPeer) error {
 	return bs.addRestricted(suspended, suspendedPeersID)
 }
 
-func (bs *CBORStorage) addRestricted(restricted []RestrictedPeer, peersID restrictedPeersID) error {
+func (bs *CBORStorage) addRestricted(restricted []restrictedPeer, peersID restrictedPeersID) error {
 	if len(restricted) == 0 {
 		return nil
 	}
@@ -271,7 +271,7 @@ func (bs *CBORStorage) DeleteSuspendedByIP(suspended []SuspendedPeer) error {
 	return bs.deleteRestrictedByIP(suspended, suspendedPeersID)
 }
 
-func (bs *CBORStorage) deleteRestrictedByIP(restricted []RestrictedPeer, peersID restrictedPeersID) error {
+func (bs *CBORStorage) deleteRestrictedByIP(restricted []restrictedPeer, peersID restrictedPeersID) error {
 	if len(restricted) == 0 {
 		return nil
 	}
@@ -306,7 +306,7 @@ func (bs *CBORStorage) refreshRestricted(now time.Time, restrictedID restrictedP
 	bs.rwMutex.Lock()
 	defer bs.rwMutex.Unlock()
 
-	var backup []RestrictedPeer
+	var backup []restrictedPeer
 	for _, s := range *bs.restrictedPeersByType(restrictedID) {
 		if !s.IsRestricted(now) {
 			backup = append(backup, s)
@@ -458,7 +458,7 @@ func restrictedNameByID(peersID restrictedPeersID) string {
 	}
 }
 
-func (bs *CBORStorage) unsafeSyncRestricted(newEntries, backup []RestrictedPeer, peersID restrictedPeersID) error {
+func (bs *CBORStorage) unsafeSyncRestricted(newEntries, backup []restrictedPeer, peersID restrictedPeersID) error {
 	if err := marshalToCborAndSyncToFile(bs.restrictedFilePathByID(peersID), bs.restrictedPeersByType(peersID)); err != nil {
 		// Remove suspended from map to eliminate side effects
 		for _, s := range newEntries {
@@ -495,8 +495,8 @@ func (bs *CBORStorage) unsafeKnownIntersection(known []KnownPeer) knownPeers {
 }
 
 // unsafeRestrictedIntersection returns values from suspended map which intersects with input values
-func (bs *CBORStorage) unsafeRestrictedIntersection(restricted []RestrictedPeer, peersType restrictedPeersID) []RestrictedPeer {
-	var intersection []RestrictedPeer
+func (bs *CBORStorage) unsafeRestrictedIntersection(restricted []restrictedPeer, peersType restrictedPeersID) []restrictedPeer {
+	var intersection []restrictedPeer
 	for _, newRestricted := range restricted {
 		if storedPeer, in := (*bs.restrictedPeersByType(peersType))[newRestricted.IP]; in {
 			intersection = append(intersection, storedPeer)

--- a/pkg/node/peer_manager/storage/cbor.go
+++ b/pkg/node/peer_manager/storage/cbor.go
@@ -113,6 +113,8 @@ func newCBORStorageInDir(storageDir string, now time.Time, currVersion int) (*CB
 		return nil, errors.Wrapf(err, "failed to load suspended peers from file %q", suspendedFile)
 	}
 
+	// TODO(artemreyt): blacklist unmarshal
+
 	if len(storage.suspended) != 0 {
 		// Remove expired peers
 		if err := storage.RefreshSuspended(now); err != nil {
@@ -287,6 +289,10 @@ func (bs *CBORStorage) RefreshSuspended(now time.Time) error {
 	return bs.refreshRestricted(now, suspendedFieldID)
 }
 
+func (bs *CBORStorage) RefreshBlackList(now time.Time) error {
+	return bs.refreshRestricted(now, blackListedFieldID)
+}
+
 func (bs *CBORStorage) refreshRestricted(now time.Time, restrictedID restrictedPeersID) error {
 	bs.rwMutex.Lock()
 	defer bs.rwMutex.Unlock()
@@ -336,8 +342,8 @@ func (bs *CBORStorage) IsBlackListedIP(ip IP, now time.Time) bool {
 	return bs.isRestrictedIP(ip, now, blackListedFieldID)
 }
 
-func (bs *CBORStorage) IsBlackListedIPs(ip []IP, now time.Time) []bool {
-	return bs.isRestrictedIPs(ip, now, blackListedFieldID)
+func (bs *CBORStorage) IsBlackListedIPs(ips []IP, now time.Time) []bool {
+	return bs.isRestrictedIPs(ips, now, blackListedFieldID)
 }
 
 func (bs *CBORStorage) DeleteBlackListedByIP(restricted []BlackListedPeer) error {

--- a/pkg/node/peer_manager/storage/cbor_test.go
+++ b/pkg/node/peer_manager/storage/cbor_test.go
@@ -215,7 +215,7 @@ func (s *binaryStorageCborSuite) TestCBORStorageKnown() {
 func (s *binaryStorageCborSuite) TestCBORStorageSuspended() {
 	suspendDuration := time.Minute * 5
 	now := s.now.Truncate(time.Millisecond)
-	suspended := []RestrictedPeer{
+	suspended := []SuspendedPeer{
 		{
 			IP:                      IPFromString("13.3.4.1"),
 			RestrictTimestampMillis: now.UnixNano() / 1_000_000,
@@ -354,7 +354,147 @@ func (s *binaryStorageCborSuite) TestCBORStorageSuspended() {
 		}()
 
 		s.storage.suspendedFilePath = badFilePath
-		err = s.storage.unsafeSyncRestricted(nil, nil, suspendedFieldID)
+		err = s.storage.unsafeSyncRestricted(nil, nil, suspendedPeersID)
+		require.Error(s.T(), err)
+	})
+}
+
+func (s *binaryStorageCborSuite) TestCBORStorageBlackList() {
+	blackListDuration := time.Minute * 5
+	now := s.now.Truncate(time.Millisecond)
+	blackList := []BlackListedPeer{
+		{
+			IP:                      IPFromString("13.3.4.1"),
+			RestrictTimestampMillis: now.UnixNano() / 1_000_000,
+			RestrictDuration:        blackListDuration,
+			Reason:                  "some reason #1",
+		},
+		{
+			IP:                      IPFromString("3.54.1.9"),
+			RestrictTimestampMillis: now.UnixNano() / 1_000_000,
+			RestrictDuration:        blackListDuration,
+			Reason:                  "some reason #2",
+		},
+		{
+			IP:                      IPFromString("23.43.7.43"),
+			RestrictTimestampMillis: now.UnixNano() / 1_000_000,
+			RestrictDuration:        blackListDuration + time.Minute*2,
+			Reason:                  "some reason #3",
+		},
+		{
+			IP:                      IPFromString("42.54.1.6"),
+			RestrictTimestampMillis: now.UnixNano() / 1_000_000,
+			RestrictDuration:        blackListDuration + time.Minute*2,
+			Reason:                  "some reason #4",
+		},
+	}
+
+	check := func(blackList []RestrictedPeer) {
+		var unmarshalled restrictedPeers
+		require.NoError(s.T(), unmarshalCborFromFile(s.storage.blackListFilePath, &unmarshalled))
+		assert.Equal(s.T(), len(blackList), len(unmarshalled))
+
+		for _, expected := range blackList {
+			_, in := unmarshalled[expected.IP]
+			require.True(s.T(), in)
+		}
+
+		cachedBlackList := make(restrictedPeers)
+		for _, blackListedPeer := range s.storage.BlackList(now) {
+			cachedBlackList[blackListedPeer.IP] = blackListedPeer
+		}
+
+		for k := range cachedBlackList {
+			_, in := unmarshalled[k]
+			require.True(s.T(), in)
+		}
+	}
+
+	s.Run("add and get black listed peers", func() {
+		require.NoError(s.T(), s.storage.AddToBlackList(nil))
+
+		err := s.storage.AddToBlackList(blackList)
+		require.NoError(s.T(), err)
+		check(blackList)
+	})
+
+	s.Run("ip is black listed", func() {
+		for _, peer := range blackList {
+			require.True(s.T(), s.storage.IsBlackListedIP(peer.IP, now))
+		}
+	})
+
+	s.Run("ips are black listed", func() {
+		empty := s.storage.IsBlackListedIPs(nil, now)
+		assert.Empty(s.T(), empty)
+
+		ips := make([]IP, 0, len(blackList))
+		for _, peer := range blackList {
+			ips = append(ips, peer.IP)
+		}
+		res := s.storage.IsBlackListedIPs(ips, now.Add(blackListDuration))
+		assert.False(s.T(), res[0])
+		assert.False(s.T(), res[1])
+		assert.True(s.T(), res[2])
+		assert.True(s.T(), res[3])
+	})
+
+	s.Run("delete and get black listed peers", func() {
+		defer func() {
+			require.NoError(s.T(), s.storage.AddToBlackList(blackList))
+		}()
+
+		require.NoError(s.T(), s.storage.DeleteBlackListedByIP(nil))
+
+		err := s.storage.DeleteBlackListedByIP(blackList[:1])
+		require.NoError(s.T(), err)
+		check(blackList[1:])
+	})
+
+	s.Run("refresh black listed peers", func() {
+		err := s.storage.RefreshBlackList(now.Add(blackListDuration))
+		require.NoError(s.T(), err)
+		check(blackList[2:])
+	})
+
+	s.Run("new cbor storage with black list refreshing", func() {
+		defer func() {
+			require.NoError(s.T(), s.storage.AddToBlackList(blackList))
+		}()
+
+		newNow := now.Add(blackListDuration)
+		storage, err := newCBORStorageInDir(s.storage.storageDir, newNow, peersStorageCurrentVersion)
+		require.NoError(s.T(), err)
+		s.storage = storage
+
+		testMap := make(restrictedPeers)
+		for _, peer := range s.storage.BlackList(newNow) {
+			testMap[peer.IP] = peer
+		}
+
+		for _, peer := range blackList[2:] {
+			inMapPeer, in := testMap[peer.IP]
+			assert.True(s.T(), in)
+			assert.Equal(s.T(), peer, inMapPeer)
+		}
+	})
+
+	s.Run("unsafe sync black listed peers bad storage file", func() {
+		defer func(blackListStorageFile string) {
+			require.NoError(s.T(), os.Remove(s.storage.blackListFilePath))
+			s.storage.blackListFilePath = blackListStorageFile
+		}(s.storage.blackListFilePath)
+
+		badFilePath := filepath.Join(s.storage.storageDir, "test_invalid_black_list_storage_file")
+		f, err := os.OpenFile(badFilePath, os.O_CREATE, 0100)
+		require.NoError(s.T(), err)
+		defer func() {
+			require.NoError(s.T(), f.Chmod(0644))
+			require.NoError(s.T(), f.Close())
+		}()
+
+		s.storage.blackListFilePath = badFilePath
+		err = s.storage.unsafeSyncRestricted(nil, nil, blackListedPeersID)
 		require.Error(s.T(), err)
 	})
 }

--- a/pkg/node/peer_manager/storage/cbor_test.go
+++ b/pkg/node/peer_manager/storage/cbor_test.go
@@ -23,7 +23,7 @@ func TestMarshalUnmarshalCborFromFile(t *testing.T) {
 		require.NoError(t, os.Remove(filename))
 	}()
 
-	expected := RestrictedPeer{
+	expected := restrictedPeer{
 		IP:                      IPFromString("13.3.4.1"),
 		RestrictTimestampMillis: time.Now().UnixNano() / 1_000_000,
 		RestrictDuration:        time.Minute * 5,
@@ -36,7 +36,7 @@ func TestMarshalUnmarshalCborFromFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// nickeskov: check marshalling
-	actual := RestrictedPeer{}
+	actual := restrictedPeer{}
 	err = cbor.NewDecoder(tmpFile).Decode(&actual)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
@@ -60,7 +60,7 @@ func TestUnmarshalCborFromEmptyFile(t *testing.T) {
 		require.NoError(t, os.Remove(filename))
 	}()
 
-	dummy := RestrictedPeer{}
+	dummy := restrictedPeer{}
 	err = unmarshalCborFromFile(tmpFile.Name(), &dummy)
 	assert.Equal(t, io.EOF, err)
 }
@@ -242,7 +242,7 @@ func (s *binaryStorageCborSuite) TestCBORStorageSuspended() {
 		},
 	}
 
-	check := func(suspended []RestrictedPeer) {
+	check := func(suspended []restrictedPeer) {
 		var unmarshalled restrictedPeers
 		require.NoError(s.T(), unmarshalCborFromFile(s.storage.suspendedFilePath, &unmarshalled))
 		assert.Equal(s.T(), len(suspended), len(unmarshalled))
@@ -389,7 +389,7 @@ func (s *binaryStorageCborSuite) TestCBORStorageBlackList() {
 		},
 	}
 
-	check := func(blackList []RestrictedPeer) {
+	check := func(blackList []restrictedPeer) {
 		var unmarshalled restrictedPeers
 		require.NoError(s.T(), unmarshalCborFromFile(s.storage.blackListFilePath, &unmarshalled))
 		assert.Equal(s.T(), len(blackList), len(unmarshalled))
@@ -502,7 +502,7 @@ func (s *binaryStorageCborSuite) TestCBORStorageBlackList() {
 func (s *binaryStorageCborSuite) TestCBORStorageDropsAndVersioning() {
 	suspendDuration := time.Minute * 5
 	now := s.now.Truncate(time.Millisecond)
-	suspended := []RestrictedPeer{
+	suspended := []restrictedPeer{
 		{
 			IP:                      IPFromString("13.3.4.1"),
 			RestrictTimestampMillis: now.UnixNano() / 1_000_000,

--- a/pkg/node/peer_manager/storage/types.go
+++ b/pkg/node/peer_manager/storage/types.go
@@ -50,7 +50,7 @@ type restrictedPeer struct {
 }
 
 func (sp *restrictedPeer) RestrictTime() time.Time {
-	return fromUnixMillis(sp.RestrictTimestampMillis)
+	return time.UnixMilli(sp.RestrictTimestampMillis)
 }
 
 func (sp *restrictedPeer) AwakeTime() time.Time {
@@ -122,10 +122,4 @@ func (a knownPeers) OldestFirst(limit int) []KnownPeer {
 		r[i] = ps[i].peer
 	}
 	return r
-}
-
-func fromUnixMillis(timestampMillis int64) time.Time {
-	sec := timestampMillis / 1_000
-	nsec := (timestampMillis % 1_000) * 1_000_000
-	return time.Unix(sec, nsec)
 }

--- a/pkg/node/peer_manager/storage/types.go
+++ b/pkg/node/peer_manager/storage/types.go
@@ -42,29 +42,29 @@ func (kp *KnownPeer) String() string {
 	return ipPort.String()
 }
 
-type RestrictedPeer struct {
+type restrictedPeer struct {
 	IP                      IP            `cbor:"0,keyasint,omitemtpy"`
 	RestrictTimestampMillis int64         `cbor:"1,keyasint,omitemtpy"`
 	RestrictDuration        time.Duration `cbor:"2,keyasint,omitemtpy"`
 	Reason                  string        `cbor:"3,keyasint,omitemtpy"`
 }
 
-func (sp *RestrictedPeer) RestrictTime() time.Time {
+func (sp *restrictedPeer) RestrictTime() time.Time {
 	return fromUnixMillis(sp.RestrictTimestampMillis)
 }
 
-func (sp *RestrictedPeer) AwakeTime() time.Time {
+func (sp *restrictedPeer) AwakeTime() time.Time {
 	return sp.RestrictTime().Add(sp.RestrictDuration)
 }
 
-func (sp *RestrictedPeer) IsRestricted(now time.Time) bool {
+func (sp *restrictedPeer) IsRestricted(now time.Time) bool {
 	awakeTime := sp.AwakeTime()
 	return awakeTime.After(now)
 }
 
-type restrictedPeers map[IP]RestrictedPeer
+type restrictedPeers map[IP]restrictedPeer
 
-type SuspendedPeer = RestrictedPeer
+type SuspendedPeer = restrictedPeer
 
 func NewSuspendedPeer(ip IP, suspendTimestampMillis int64, suspendDuration time.Duration, reason string) *SuspendedPeer {
 	return &SuspendedPeer{
@@ -77,7 +77,7 @@ func NewSuspendedPeer(ip IP, suspendTimestampMillis int64, suspendDuration time.
 
 type suspendedPeers = restrictedPeers
 
-type BlackListedPeer = RestrictedPeer
+type BlackListedPeer = restrictedPeer
 
 func NewBlackListedPeer(ip IP, blackListTimestampMillis int64, blackListDuration time.Duration, reason string) *BlackListedPeer {
 	return &BlackListedPeer{

--- a/pkg/node/peer_manager/storage/types.go
+++ b/pkg/node/peer_manager/storage/types.go
@@ -66,8 +66,8 @@ type restrictedPeers map[IP]restrictedPeer
 
 type SuspendedPeer = restrictedPeer
 
-func NewSuspendedPeer(ip IP, suspendTimestampMillis int64, suspendDuration time.Duration, reason string) *SuspendedPeer {
-	return &SuspendedPeer{
+func NewSuspendedPeer(ip IP, suspendTimestampMillis int64, suspendDuration time.Duration, reason string) SuspendedPeer {
+	return SuspendedPeer{
 		IP:                      ip,
 		RestrictTimestampMillis: suspendTimestampMillis,
 		RestrictDuration:        suspendDuration,
@@ -79,8 +79,8 @@ type suspendedPeers = restrictedPeers
 
 type BlackListedPeer = restrictedPeer
 
-func NewBlackListedPeer(ip IP, blackListTimestampMillis int64, blackListDuration time.Duration, reason string) *BlackListedPeer {
-	return &BlackListedPeer{
+func NewBlackListedPeer(ip IP, blackListTimestampMillis int64, blackListDuration time.Duration, reason string) BlackListedPeer {
+	return BlackListedPeer{
 		IP:                      ip,
 		RestrictTimestampMillis: blackListTimestampMillis,
 		RestrictDuration:        blackListDuration,

--- a/pkg/node/peer_manager/storage/types.go
+++ b/pkg/node/peer_manager/storage/types.go
@@ -42,27 +42,53 @@ func (kp *KnownPeer) String() string {
 	return ipPort.String()
 }
 
-type SuspendedPeer struct {
-	IP                     IP            `cbor:"0,keyasint,omitemtpy"`
-	SuspendTimestampMillis int64         `cbor:"1,keyasint,omitemtpy"`
-	SuspendDuration        time.Duration `cbor:"2,keyasint,omitemtpy"`
-	Reason                 string        `cbor:"3,keyasint,omitemtpy"`
+type RestrictedPeer struct {
+	IP                      IP            `cbor:"0,keyasint,omitemtpy"`
+	RestrictTimestampMillis int64         `cbor:"1,keyasint,omitemtpy"`
+	RestrictDuration        time.Duration `cbor:"2,keyasint,omitemtpy"`
+	Reason                  string        `cbor:"3,keyasint,omitemtpy"`
 }
 
-func (sp *SuspendedPeer) SuspendTime() time.Time {
-	return fromUnixMillis(sp.SuspendTimestampMillis)
+func (sp *RestrictedPeer) RestrictTime() time.Time {
+	return fromUnixMillis(sp.RestrictTimestampMillis)
 }
 
-func (sp *SuspendedPeer) AwakeTime() time.Time {
-	return sp.SuspendTime().Add(sp.SuspendDuration)
+func (sp *RestrictedPeer) AwakeTime() time.Time {
+	return sp.RestrictTime().Add(sp.RestrictDuration)
 }
 
-func (sp *SuspendedPeer) IsSuspended(now time.Time) bool {
+func (sp *RestrictedPeer) IsRestricted(now time.Time) bool {
 	awakeTime := sp.AwakeTime()
 	return awakeTime.After(now)
 }
 
-type suspendedPeers map[IP]SuspendedPeer
+type restrictedPeers map[IP]RestrictedPeer
+
+type SuspendedPeer = RestrictedPeer
+
+func NewSuspendedPeer(ip IP, suspendTimestampMillis int64, suspendDuration time.Duration, reason string) *SuspendedPeer {
+	return &SuspendedPeer{
+		IP:                      ip,
+		RestrictTimestampMillis: suspendTimestampMillis,
+		RestrictDuration:        suspendDuration,
+		Reason:                  reason,
+	}
+}
+
+type suspendedPeers = restrictedPeers
+
+type BlackListedPeer = RestrictedPeer
+
+func NewBlackListedPeer(ip IP, blackListTimestampMillis int64, blackListDuration time.Duration, reason string) *BlackListedPeer {
+	return &BlackListedPeer{
+		IP:                      ip,
+		RestrictTimestampMillis: blackListTimestampMillis,
+		RestrictDuration:        blackListDuration,
+		Reason:                  reason,
+	}
+}
+
+type blackListedPeers = restrictedPeers
 
 type pair struct {
 	peer KnownPeer

--- a/pkg/node/peer_manager/storage/types_test.go
+++ b/pkg/node/peer_manager/storage/types_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestFromUnixMillis(t *testing.T) {
 	ts := time.Now().Truncate(time.Millisecond)
-	tsMillis := ts.UnixNano() / 1_000_000
+	tsMillis := ts.UnixMilli()
 
 	require.Equal(t, ts.String(), fromUnixMillis(tsMillis).String())
 }

--- a/pkg/node/peer_manager/storage/types_test.go
+++ b/pkg/node/peer_manager/storage/types_test.go
@@ -2,19 +2,11 @@ package storage
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wavesplatform/gowaves/pkg/proto"
 )
-
-func TestFromUnixMillis(t *testing.T) {
-	ts := time.Now().Truncate(time.Millisecond)
-	tsMillis := ts.UnixMilli()
-
-	require.Equal(t, ts.String(), fromUnixMillis(tsMillis).String())
-}
 
 func TestIpFromIpPort(t *testing.T) {
 	ip := IpFromIpPort(proto.NewIpPortFromTcpAddr(proto.NewTCPAddrFromString("13.3.4.1:2345")))

--- a/pkg/node/state_fsm/fsm_common.go
+++ b/pkg/node/state_fsm/fsm_common.go
@@ -22,7 +22,7 @@ func newPeer(fsm FSM, p peer.Peer, peers peer_manager.PeerManager) (FSM, Async, 
 	return fsm, nil, nil
 }
 
-func transaction(fsm FSM, baseInfo BaseInfo, p peer.Peer, t proto.Transaction) (FSM, Async, error) {
+func tryBroadcastTransaction(fsm FSM, baseInfo BaseInfo, p peer.Peer, t proto.Transaction) (FSM, Async, error) {
 	t, err := t.Validate(baseInfo.scheme)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to validate transaction")

--- a/pkg/node/state_fsm/fsm_common.go
+++ b/pkg/node/state_fsm/fsm_common.go
@@ -34,9 +34,6 @@ func transaction(fsm FSM, baseInfo BaseInfo, p peer.Peer, t proto.Transaction) (
 
 	if err := baseInfo.utx.Add(t); err != nil {
 		err = errors.Wrap(err, "Failed to add transaction to utx")
-		if p != nil {
-			baseInfo.peers.AddToBlackList(p, time.Now(), err.Error())
-		}
 		return fsm, nil, fsm.Errorf(proto.NewInfoMsg(err))
 	}
 	baseInfo.BroadcastTransaction(t, p)

--- a/pkg/node/state_fsm/fsm_common.go
+++ b/pkg/node/state_fsm/fsm_common.go
@@ -17,7 +17,7 @@ import (
 func newPeer(fsm FSM, p peer.Peer, peers peer_manager.PeerManager) (FSM, Async, error) {
 	err := peers.NewConnection(p)
 	if err != nil {
-		return fsm, nil, proto.NewInfoMsg(err)
+		return fsm, nil, fsm.Errorf(proto.NewInfoMsg(err))
 	}
 	return fsm, nil, nil
 }

--- a/pkg/node/state_fsm/fsm_idle.go
+++ b/pkg/node/state_fsm/fsm_idle.go
@@ -35,12 +35,7 @@ type IdleFsm struct {
 }
 
 func (a *IdleFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	err := a.baseInfo.utx.Add(t)
-	if err != nil {
-		return a, nil, proto.NewInfoMsg(err)
-	}
-	a.baseInfo.BroadcastTransaction(t, p)
-	return a, nil, nil
+	return transaction(a, a.baseInfo, p, t)
 }
 
 func (a *IdleFsm) Halt() (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_idle.go
+++ b/pkg/node/state_fsm/fsm_idle.go
@@ -35,7 +35,7 @@ type IdleFsm struct {
 }
 
 func (a *IdleFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	return transaction(a, a.baseInfo, p, t)
+	return tryBroadcastTransaction(a, a.baseInfo, p, t)
 }
 
 func (a *IdleFsm) Halt() (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_idle.go
+++ b/pkg/node/state_fsm/fsm_idle.go
@@ -83,12 +83,12 @@ func (a *IdleFsm) BlockIDs(_ peer.Peer, _ []proto.BlockID) (FSM, Async, error) {
 }
 
 func (a *IdleFsm) NewPeer(p peer.Peer) (FSM, Async, error) {
-	fsm, as, err := newPeer(a, p, a.baseInfo.peers)
+	fsm, as, fsmErr := newPeer(a, p, a.baseInfo.peers)
 	if a.baseInfo.peers.ConnectedCount() == a.baseInfo.minPeersMining {
 		a.baseInfo.Reschedule()
 	}
 	sendScore(p, a.baseInfo.storage)
-	return fsm, as, a.Errorf(err)
+	return fsm, as, fsmErr
 }
 
 func (a *IdleFsm) Score(p peer.Peer, score *proto.Score) (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_ng.go
+++ b/pkg/node/state_fsm/fsm_ng.go
@@ -61,12 +61,12 @@ func NewNGFsm12(info BaseInfo) *NGFsm {
 }
 
 func (a *NGFsm) NewPeer(p peer.Peer) (FSM, Async, error) {
-	fsm, as, err := newPeer(a, p, a.baseInfo.peers)
+	fsm, as, fsmErr := newPeer(a, p, a.baseInfo.peers)
 	if a.baseInfo.peers.ConnectedCount() == a.baseInfo.minPeersMining {
 		a.baseInfo.Reschedule()
 	}
 	sendScore(p, a.baseInfo.storage)
-	return fsm, as, a.Errorf(err)
+	return fsm, as, fsmErr
 }
 
 func (a *NGFsm) PeerError(p peer.Peer, e error) (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_ng.go
+++ b/pkg/node/state_fsm/fsm_ng.go
@@ -23,7 +23,7 @@ var (
 )
 
 func (a *NGFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	return transaction(a, a.baseInfo, p, t)
+	return tryBroadcastTransaction(a, a.baseInfo, p, t)
 }
 
 func (a *NGFsm) Task(task AsyncTask) (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_ng.go
+++ b/pkg/node/state_fsm/fsm_ng.go
@@ -23,12 +23,7 @@ var (
 )
 
 func (a *NGFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	err := a.baseInfo.utx.Add(t)
-	if err != nil {
-		return a, nil, a.Errorf(proto.NewInfoMsg(err))
-	}
-	a.baseInfo.BroadcastTransaction(t, p)
-	return a, nil, nil
+	return transaction(a, a.baseInfo, p, t)
 }
 
 func (a *NGFsm) Task(task AsyncTask) (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_sync.go
+++ b/pkg/node/state_fsm/fsm_sync.go
@@ -135,11 +135,7 @@ func (a *SyncFsm) BlockIDs(peer peer.Peer, signatures []proto.BlockID) (FSM, Asy
 }
 
 func (a *SyncFsm) NewPeer(p peer.Peer) (FSM, Async, error) {
-	err := a.baseInfo.peers.NewConnection(p)
-	if err != nil {
-		return a, nil, a.Errorf(proto.NewInfoMsg(err))
-	}
-	return a, nil, nil
+	return newPeer(a, p, a.baseInfo.peers)
 }
 
 func (a *SyncFsm) Score(p peer.Peer, score *proto.Score) (FSM, Async, error) {

--- a/pkg/node/state_fsm/fsm_sync.go
+++ b/pkg/node/state_fsm/fsm_sync.go
@@ -60,7 +60,7 @@ type SyncFsm struct {
 }
 
 func (a *SyncFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	return transaction(a, a.baseInfo, p, t)
+	return tryBroadcastTransaction(a, a.baseInfo, p, t)
 }
 
 // MicroBlock ignores new microblocks while syncing.
@@ -226,7 +226,7 @@ func (a *SyncFsm) applyBlocks(baseInfo BaseInfo, conf conf, internal sync_intern
 	})
 	if err != nil {
 		if errs.IsValidationError(err) || errs.IsValidationError(errors.Cause(err)) {
-			a.baseInfo.peers.AddToBlackList(conf.peerSyncWith, time.Now(), err.Error())
+			a.baseInfo.peers.Suspend(conf.peerSyncWith, time.Now(), err.Error())
 		}
 		for _, b := range blocks {
 			metrics.FSMKeyBlockDeclined("sync", b, err)

--- a/pkg/node/state_fsm/fsm_sync.go
+++ b/pkg/node/state_fsm/fsm_sync.go
@@ -60,12 +60,7 @@ type SyncFsm struct {
 }
 
 func (a *SyncFsm) Transaction(p peer.Peer, t proto.Transaction) (FSM, Async, error) {
-	err := a.baseInfo.utx.Add(t)
-	if err != nil {
-		return a, nil, a.Errorf(proto.NewInfoMsg(err))
-	}
-	a.baseInfo.BroadcastTransaction(t, p)
-	return a, nil, nil
+	return transaction(a, a.baseInfo, p, t)
 }
 
 // MicroBlock ignores new microblocks while syncing.
@@ -231,7 +226,7 @@ func (a *SyncFsm) applyBlocks(baseInfo BaseInfo, conf conf, internal sync_intern
 	})
 	if err != nil {
 		if errs.IsValidationError(err) || errs.IsValidationError(errors.Cause(err)) {
-			a.baseInfo.peers.Suspend(conf.peerSyncWith, time.Now(), err.Error())
+			a.baseInfo.peers.AddToBlackList(conf.peerSyncWith, time.Now(), err.Error())
 		}
 		for _, b := range blocks {
 			metrics.FSMKeyBlockDeclined("sync", b, err)

--- a/pkg/util/common/util.go
+++ b/pkg/util/common/util.go
@@ -224,7 +224,7 @@ func UnixMillisToTime(ts int64) time.Time {
 }
 
 func UnixMillisFromTime(t time.Time) int64 {
-	return t.UnixNano() / 1_000_000
+	return t.UnixMilli()
 }
 
 // ReplaceInvalidUtf8Chars replaces invalid utf8 characters with '?' to reproduce JVM behaviour.

--- a/pkg/util/common/util_test.go
+++ b/pkg/util/common/util_test.go
@@ -103,7 +103,7 @@ func TestReplaceInvalidUtf8Chars(t *testing.T) {
 
 func TestUnixMillisUtils(t *testing.T) {
 	ts := time.Now().Truncate(time.Millisecond)
-	tsMillis := ts.UnixNano() / 1_000_000
+	tsMillis := ts.UnixMilli()
 
 	require.Equal(t, tsMillis, UnixMillisFromTime(ts))
 	require.Equal(t, ts.String(), UnixMillisToTime(tsMillis).String())


### PR DESCRIPTION
Now, node prevents establishing outgoing connections with peers in`suspended` list and incoming connections with peers in `blackList` as it works in scala node.