### PR TITLE
Add hex string representation for 'crypto.Digest'.

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"strings"
@@ -38,6 +39,10 @@ type Digest [DigestSize]byte
 
 func (d Digest) String() string {
 	return base58.Encode(d[:])
+}
+
+func (d Digest) Hex() string {
+	return hex.EncodeToString(d[:])
 }
 
 func (d Digest) ShortString() string {

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -377,3 +377,10 @@ func TestDigest_Marshal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, d, d1)
 }
+
+func TestDigest_Hex(t *testing.T) {
+	s := "BXBUNddxTGTQc3G4qHYn5E67SBwMj18zLncUr871iuRD"
+	d, err := NewDigestFromBase58(s)
+	require.NoError(t, err)
+	require.Equal(t, "9c50225b3c88651cd7ddf9268941cfa6d8737edea0f0ed49c380334953361634", d.Hex())
+}


### PR DESCRIPTION
Need for [wavesplatform/nodemon/issues/92](https://github.com/wavesplatform/nodemon/issues/92).