### PR TITLE
move callee dapp version check in invoke() to the beginning

### DIFF
--- a/pkg/ride/functions_invocations.go
+++ b/pkg/ride/functions_invocations.go
@@ -2,16 +2,12 @@ package ride
 
 import (
 	"github.com/wavesplatform/gowaves/pkg/proto"
-	"github.com/wavesplatform/gowaves/pkg/ride/ast"
 )
 
 func invokeFunctionFromDApp(env environment, recipient proto.Recipient, fnName rideString, listArgs rideList) (Result, error) {
 	tree, err := env.state().NewestScriptByAccount(recipient)
 	if err != nil {
 		return nil, EvaluationFailure.Wrap(err, "failed to get script by recipient")
-	}
-	if tree.LibVersion < ast.LibV5 {
-		return nil, RuntimeError.Errorf("failed to call 'invoke' for script with version %d. Scripts with version 5 are only allowed to be used in 'invoke'", tree.LibVersion)
 	}
 	args, err := convertListArguments(listArgs, env.rideV6Activated())
 	if err != nil {

--- a/pkg/ride/functions_invocations.go
+++ b/pkg/ride/functions_invocations.go
@@ -1,14 +1,10 @@
 package ride
 
 import (
-	"github.com/wavesplatform/gowaves/pkg/proto"
+	"github.com/wavesplatform/gowaves/pkg/ride/ast"
 )
 
-func invokeFunctionFromDApp(env environment, recipient proto.Recipient, fnName rideString, listArgs rideList) (Result, error) {
-	tree, err := env.state().NewestScriptByAccount(recipient)
-	if err != nil {
-		return nil, EvaluationFailure.Wrap(err, "failed to get script by recipient")
-	}
+func invokeFunctionFromDApp(env environment, tree *ast.Tree, fnName rideString, listArgs rideList) (Result, error) {
 	args, err := convertListArguments(listArgs, env.rideV6Activated())
 	if err != nil {
 		return nil, EvaluationFailure.Wrapf(err, "failed to invoke function '%s'", fnName)

--- a/pkg/ride/functions_proto.go
+++ b/pkg/ride/functions_proto.go
@@ -137,16 +137,16 @@ func performInvoke(invocation invocation, env environment, args ...rideType) (ri
 		return nil, RuntimeError.Wrap(err, invocation.name())
 	}
 
-	recipientVer, err := ws.NewestScriptVersionByAddressID(recipient.Address.ID())
+	tree, err := env.state().NewestScriptByAccount(recipient)
 	if err != nil {
-		return nil, RuntimeError.Wrapf(err, "failed to get library version of dApp %s", recipient.Address)
+		return nil, EvaluationFailure.Wrap(err, "failed to get script by recipient")
 	}
-	if recipientVer < ast.LibV5 {
-		return nil, UserError.Errorf(
+	if tree.LibVersion < ast.LibV5 {
+		return nil, RuntimeError.Errorf(
 			"DApp %s invoked DApp %s that uses RIDE %d, but dApp-to-dApp invocation requires version 5 or higher",
 			proto.WavesAddress(callerAddress),
 			recipient.Address,
-			recipientVer,
+			tree.LibVersion,
 		)
 	}
 
@@ -277,7 +277,7 @@ func performInvoke(invocation invocation, env environment, args ...rideType) (ri
 		}
 	}
 
-	res, err := invokeFunctionFromDApp(env, recipient, fn, arguments)
+	res, err := invokeFunctionFromDApp(env, tree, fn, arguments)
 	if err != nil {
 		return nil, EvaluationErrorPush(err, "%s at '%s' function %s with arguments %v", invocation.name(), recipient.Address.String(), fn, arguments)
 	}

--- a/pkg/ride/functions_proto.go
+++ b/pkg/ride/functions_proto.go
@@ -136,6 +136,20 @@ func performInvoke(invocation invocation, env environment, args ...rideType) (ri
 	if err != nil {
 		return nil, RuntimeError.Wrap(err, invocation.name())
 	}
+
+	recipientVer, err := ws.NewestScriptVersionByAddressID(recipient.Address.ID())
+	if err != nil {
+		return nil, RuntimeError.Wrapf(err, "failed to get library version of dApp %s", recipient.Address)
+	}
+	if recipientVer < ast.LibV5 {
+		return nil, UserError.Errorf(
+			"DApp %s invoked DApp %s that uses RIDE %d, but dApp-to-dApp invocation requires version 5 or higher",
+			proto.WavesAddress(callerAddress),
+			recipient.Address,
+			recipientVer,
+		)
+	}
+
 	fn, err := extractFunctionName(args[1])
 	if err != nil {
 		return nil, RuntimeError.Wrapf(err, "%s: failed to extract second argument", invocation.name())
@@ -147,10 +161,6 @@ func performInvoke(invocation invocation, env environment, args ...rideType) (ri
 
 	oldInvocationParam := env.invocation()
 	originCaller, err := oldInvocationParam.get(originCallerField)
-	if err != nil {
-		return nil, RuntimeError.Wrapf(err, "%s: failed to get field from oldInvocation", invocation.name())
-	}
-	payment, err := oldInvocationParam.get(paymentField)
 	if err != nil {
 		return nil, RuntimeError.Wrapf(err, "%s: failed to get field from oldInvocation", invocation.name())
 	}
@@ -189,7 +199,7 @@ func performInvoke(invocation invocation, env environment, args ...rideType) (ri
 	env.setInvocation(newRideInvocation(
 		originCaller,
 		payments,
-		payment,
+		rideUnit{},
 		common.Dup(callerPublicKey.Bytes()),
 		feeAssetID,
 		originCallerPublicKey,


### PR DESCRIPTION
Also accessing to `payment` field of `rideInvocation` removed because this field doesn't exist in Ride`Invocation` structure  since RideV5.

This PR is followed up by #935 where Ride structures of different versions will be represented.