### PR TITLE
Handle negative peer nonce in API client correctly.

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -288,7 +288,7 @@ func main() {
 	utx := utxpool.New(uint64(1024*mb), utxpool.NewValidator(st, ntpTime, outdatePeriodSeconds*1000), cfg)
 	parent := peer.NewParent()
 
-	nodeNonce, err := rand.Int(rand.Reader, new(big.Int).SetUint64(math.MaxUint64))
+	nodeNonce, err := rand.Int(rand.Reader, new(big.Int).SetUint64(math.MaxInt32))
 	if err != nil {
 		zap.S().Errorf("Failed to get node's nonce: %v", err)
 		return

--- a/pkg/client/peers.go
+++ b/pkg/client/peers.go
@@ -62,7 +62,7 @@ type PeersConnectedRow struct {
 	Address            proto.PeerInfo `json:"address"`
 	DeclaredAddress    proto.PeerInfo `json:"declaredAddress"`
 	PeerName           string         `json:"peerName"`
-	PeerNonce          uint64         `json:"peerNonce"`
+	PeerNonce          int64          `json:"peerNonce"`
 	ApplicationName    string         `json:"applicationName"`
 	ApplicationVersion string         `json:"applicationVersion"`
 }


### PR DESCRIPTION
Do not generate random nonce more than MaxInt32.