### PR TITLE
Network connections removed from suite fields.

### DIFF
--- a/itests/fixtures/base_fixtures.go
+++ b/itests/fixtures/base_fixtures.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/wavesplatform/gowaves/itests/config"
 	d "github.com/wavesplatform/gowaves/itests/docker"
-	"github.com/wavesplatform/gowaves/itests/net"
 	"github.com/wavesplatform/gowaves/itests/node_client"
 )
 
@@ -20,7 +19,6 @@ type BaseSuite struct {
 	Cancel  context.CancelFunc
 	Cfg     config.TestConfig
 	Docker  *d.Docker
-	Conns   net.NodeConnections
 	Clients *node_client.NodesClients
 	Ports   *d.Ports
 }
@@ -44,13 +42,6 @@ func (suite *BaseSuite) SetupSuite() {
 		suite.Require().NoError(err, "couldn't run Docker containers")
 	}
 	suite.Ports = ports
-
-	conns, err := net.NewNodeConnections(ports)
-	if err != nil {
-		docker.Finish(suite.Cancel)
-		suite.Require().NoError(err, "failed to create new node connections")
-	}
-	suite.Conns = conns
 	suite.Clients = node_client.NewNodesClients(suite.T(), ports)
 }
 
@@ -59,7 +50,6 @@ func (suite *BaseSuite) TearDownSuite() {
 	suite.Clients.StateHashCmp(suite.T(), height)
 
 	suite.Docker.Finish(suite.Cancel)
-	suite.Conns.Close(suite.T())
 }
 
 func (suite *BaseSuite) SetupTest() {

--- a/itests/utilities/common_tx_utility.go
+++ b/itests/utilities/common_tx_utility.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wavesplatform/gowaves/itests/config"
 	f "github.com/wavesplatform/gowaves/itests/fixtures"
+	"github.com/wavesplatform/gowaves/itests/net"
 	"github.com/wavesplatform/gowaves/pkg/client"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/proto"
@@ -276,9 +277,11 @@ func SendAndWaitTransaction(suite *f.BaseSuite, tx proto.Transaction, scheme pro
 
 	suite.Clients.ClearBlackList(suite.T())
 
-	suite.Conns.Reconnect(suite.T(), suite.Ports)
+	connections, err := net.NewNodeConnections(suite.Ports)
+	suite.Require().NoError(err, "failed to create new node connections")
+	defer connections.Close(suite.T())
+	connections.SendToNodes(suite.T(), txMsg, scala)
 
-	suite.Conns.SendToNodes(suite.T(), txMsg, scala)
 	errGo, errScala := suite.Clients.WaitForTransaction(id, timeout)
 	return *NewConsideredTransaction(id, nil, nil, errGo, errScala, nil, nil)
 }


### PR DESCRIPTION
Function that creates new connections do it with retry. Network connections to nodes created only to send a transaction.