### PR TITLE
Reward calculator feature 19 and 21 fix

### DIFF
--- a/pkg/state/block_differ_test.go
+++ b/pkg/state/block_differ_test.go
@@ -276,8 +276,18 @@ func TestBlockRewardDistributionWithOneAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	fee := defaultFee - defaultFee/5*2
-	correctMinerWavesBalanceDiff := newBalanceDiff(int64(fee+(to.blockDiffer.settings.FunctionalitySettings.InitialBlockReward/2)), 0, 0, false)
-	correctRewardAddressBalanceDiff := newBalanceDiff(int64(to.blockDiffer.settings.FunctionalitySettings.InitialBlockReward/2), 0, 0, false)
+	correctMinerWavesBalanceDiff := newBalanceDiff(
+		int64(fee+(to.blockDiffer.settings.FunctionalitySettings.InitialBlockReward/3*2)),
+		0,
+		0,
+		false,
+	)
+	correctRewardAddressBalanceDiff := newBalanceDiff(
+		int64(to.blockDiffer.settings.FunctionalitySettings.InitialBlockReward/3),
+		0,
+		0,
+		false,
+	)
 	correctMinerWavesBalanceDiff.blockID = block2.BlockID()
 	correctRewardAddressBalanceDiff.blockID = block2.BlockID()
 	correctDiff := txDiff{

--- a/pkg/state/rewards_calculator_test.go
+++ b/pkg/state/rewards_calculator_test.go
@@ -122,8 +122,8 @@ func TestFeatures19And21RewardCalculation(t *testing.T) {
 		{2999, 2999, 6_0000_0000, makeTestNetRewards(t, gen, 2_0000_0000, 2_0000_0000, 2_0000_0000)},
 		{3000, 3000, 6_0000_0000, makeTestNetRewards(t, gen, 2_0000_0000, 2_0000_0000, 2_0000_0000)},
 		{3999, 3999, 6_0000_0000, makeTestNetRewards(t, gen, 2_0000_0000, 2_0000_0000, 2_0000_0000)},
-		{4000, 4000, 6_0000_0000, makeTestNetRewards(t, gen, 3_0000_0000, 3_0000_0000)},
-		{5000, 5000, 6_0000_0000, makeTestNetRewards(t, gen, 3_0000_0000, 3_0000_0000)},
+		{4000, 4000, 6_0000_0000, makeTestNetRewards(t, gen, 4_0000_0000, 2_0000_0000)},
+		{5000, 5000, 6_0000_0000, makeTestNetRewards(t, gen, 4_0000_0000, 2_0000_0000)},
 	} {
 		setCurrentHeight(test.currentHeight)
 		t.Run(strconv.Itoa(i+1), func(t *testing.T) {


### PR DESCRIPTION
Fixed behavior of 'rewardCalculator' when features 19 and 21 are activated without feature 20.
Share only 1/3 of reward for each reward address.