### PR TITLE
Set empty script for non-scripted assets.

### DIFF
--- a/pkg/state/snapshot_applier.go
+++ b/pkg/state/snapshot_applier.go
@@ -3,6 +3,7 @@ package state
 import (
 	"github.com/pkg/errors"
 
+	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/proto"
 	"github.com/wavesplatform/gowaves/pkg/ride"
 )
@@ -10,10 +11,43 @@ import (
 type blockSnapshotsApplier struct {
 	info *blockSnapshotsApplierInfo
 	stor snapshotApplierStorages
+
+	issuedAssets   map[crypto.Digest]struct{}
+	scriptedAssets map[crypto.Digest]struct{}
+}
+
+func (a *blockSnapshotsApplier) BeforeTxSnapshotApply() error {
+	a.issuedAssets = make(map[crypto.Digest]struct{})
+	a.scriptedAssets = make(map[crypto.Digest]struct{})
+	return nil
+}
+
+func (a *blockSnapshotsApplier) AfterTxSnapshotApply() error {
+	for assetID := range a.issuedAssets {
+		if _, ok := a.scriptedAssets[assetID]; ok { // don't set an empty script for scripted assets or script updates
+			continue
+		}
+		emptyAssetScriptSnapshot := proto.AssetScriptSnapshot{
+			AssetID: assetID,
+			Script:  proto.Script{},
+		}
+		// need for compatibility with old state hashes
+		// for issued asset without script we have to apply empty asset script snapshot
+		err := emptyAssetScriptSnapshot.Apply(a)
+		if err != nil {
+			return errors.Wrapf(err, "failed to apply empty asset scipt snapshot for asset %q", assetID)
+		}
+	}
+	return nil
 }
 
 func newBlockSnapshotsApplier(info *blockSnapshotsApplierInfo, stor snapshotApplierStorages) blockSnapshotsApplier {
-	return blockSnapshotsApplier{info: info, stor: stor}
+	return blockSnapshotsApplier{
+		info:           info,
+		stor:           stor,
+		issuedAssets:   make(map[crypto.Digest]struct{}),
+		scriptedAssets: make(map[crypto.Digest]struct{}),
+	}
 }
 
 type snapshotApplierStorages struct {
@@ -137,7 +171,12 @@ func (a *blockSnapshotsApplier) ApplyStaticAssetInfo(snapshot proto.StaticAssetI
 		},
 		assetChangeableInfo: assetChangeableInfo{},
 	}
-	return a.stor.assets.issueAsset(assetID, assetFullInfo, a.info.BlockID())
+	err := a.stor.assets.issueAsset(assetID, assetFullInfo, a.info.BlockID())
+	if err != nil {
+		return errors.Wrapf(err, "failed to issue asset %q", snapshot.AssetID.String())
+	}
+	a.issuedAssets[snapshot.AssetID] = struct{}{}
+	return nil
 }
 
 func (a *blockSnapshotsApplier) ApplyAssetDescription(snapshot proto.AssetDescriptionSnapshot) error {
@@ -161,7 +200,14 @@ func (a *blockSnapshotsApplier) ApplyAssetVolume(snapshot proto.AssetVolumeSnaps
 }
 
 func (a *blockSnapshotsApplier) ApplyAssetScript(snapshot proto.AssetScriptSnapshot) error {
-	return a.stor.scriptsStorage.setAssetScript(snapshot.AssetID, snapshot.Script, a.info.BlockID())
+	err := a.stor.scriptsStorage.setAssetScript(snapshot.AssetID, snapshot.Script, a.info.BlockID())
+	if err != nil {
+		return errors.Wrapf(err, "failed to apply asset script for asset %q", snapshot.AssetID)
+	}
+	if !snapshot.Script.IsEmpty() {
+		a.scriptedAssets[snapshot.AssetID] = struct{}{}
+	}
+	return nil
 }
 
 func (a *blockSnapshotsApplier) ApplySponsorship(snapshot proto.SponsorshipSnapshot) error {

--- a/pkg/state/snapshot_applier.go
+++ b/pkg/state/snapshot_applier.go
@@ -17,8 +17,12 @@ type blockSnapshotsApplier struct {
 }
 
 func (a *blockSnapshotsApplier) BeforeTxSnapshotApply() error {
-	a.issuedAssets = make(map[crypto.Digest]struct{})
-	a.scriptedAssets = make(map[crypto.Digest]struct{})
+	if len(a.issuedAssets) != 0 {
+		a.issuedAssets = make(map[crypto.Digest]struct{})
+	}
+	if len(a.scriptedAssets) != 0 {
+		a.scriptedAssets = make(map[crypto.Digest]struct{})
+	}
 	return nil
 }
 

--- a/pkg/state/snapshot_generator_internal_test.go
+++ b/pkg/state/snapshot_generator_internal_test.go
@@ -160,10 +160,6 @@ func TestDefaultIssueTransactionSnapshot(t *testing.T) {
 				AssetID: *tx.ID,
 				Balance: 1000,
 			},
-			&proto.AssetScriptSnapshot{
-				AssetID: *tx.ID,
-				Script:  proto.Script{},
-			},
 		},
 		internal: nil,
 	}

--- a/pkg/state/transaction_performer.go
+++ b/pkg/state/transaction_performer.go
@@ -95,7 +95,7 @@ func (tp *transactionPerformer) performTransferWithProofs(transaction proto.Tran
 
 func (tp *transactionPerformer) performIssue(tx *proto.Issue, txID crypto.Digest,
 	assetID crypto.Digest, info *performerInfo,
-	balanceChanges txDiff, scriptEstimation *scriptEstimation, script *proto.Script) (txSnapshot, error) {
+	balanceChanges txDiff, scriptEstimation *scriptEstimation, script proto.Script) (txSnapshot, error) {
 	blockHeight := info.height + 1
 	// Create new asset.
 	assetInfo := &assetInfo{
@@ -153,7 +153,7 @@ func (tp *transactionPerformer) performIssueWithProofs(transaction proto.Transac
 		return txSnapshot{}, err
 	}
 	return tp.performIssue(&tx.Issue, assetID, assetID, info,
-		balanceChanges, info.checkerData.scriptEstimation, &tx.Script)
+		balanceChanges, info.checkerData.scriptEstimation, tx.Script)
 }
 
 func (tp *transactionPerformer) performReissue(tx *proto.Reissue, _ *performerInfo,

--- a/pkg/state/tx_snapshot.go
+++ b/pkg/state/tx_snapshot.go
@@ -6,10 +6,16 @@ import (
 	"github.com/wavesplatform/gowaves/pkg/proto"
 )
 
+type snapshotApplierHooks interface {
+	BeforeTxSnapshotApply() error
+	AfterTxSnapshotApply() error
+}
+
 type extendedSnapshotApplier interface {
 	SetApplierInfo(info *blockSnapshotsApplierInfo)
 	proto.SnapshotApplier
 	internalSnapshotApplier
+	snapshotApplierHooks
 }
 
 type txSnapshot struct {
@@ -18,6 +24,9 @@ type txSnapshot struct {
 }
 
 func (ts txSnapshot) Apply(a extendedSnapshotApplier) error {
+	if err := a.BeforeTxSnapshotApply(); err != nil {
+		return errors.Wrapf(err, "failed to execute before tx snapshot apply hook")
+	}
 	// internal snapshots must be applied at the end
 	for _, rs := range ts.regular {
 		if !rs.IsGeneratedByTxDiff() {
@@ -32,6 +41,9 @@ func (ts txSnapshot) Apply(a extendedSnapshotApplier) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to apply internal transaction snapshot")
 		}
+	}
+	if err := a.AfterTxSnapshotApply(); err != nil {
+		return errors.Wrapf(err, "failed to execute after tx snapshot apply hook")
 	}
 	return nil
 }


### PR DESCRIPTION
Due to compatibility with old statehashes we have to set an empty script for any new non-scripted asset.