### PR TITLE
Return previous snapshot state hash if init snapshot is empty.

### DIFF
--- a/pkg/state/appender.go
+++ b/pkg/state/appender.go
@@ -666,9 +666,11 @@ func calculateInitialSnapshotStateHash(
 		if len(txSnapshot) != 0 { // sanity check
 			return crypto.Digest{}, errors.New("initial block snapshot for genesis block must be empty")
 		}
-		return prevHash, nil // return initial state hash as is
+		return prevHash, nil // return prevHash state hash as initial state hash
 	}
-	// TODO: can initial txSnapshot be empty? (at least before NG activation)
+	if len(txSnapshot) == 0 {
+		return prevHash, nil // return prevHash state hash as initial state hash
+	}
 	var txID []byte // txID is necessary only for txStatus atomic snapshot; init snapshot can't have such message
 	return calculateTxSnapshotStateHash(h, txID, blockHeight, prevHash, txSnapshot)
 }


### PR DESCRIPTION
According to the scala node [code](https://github.com/wavesplatform/Waves/blob/version-1.5.x/node/src/main/scala/com/wavesplatform/state/diffs/BlockDiffer.scala#L318-L323).
Continuation of #1269