### PR TITLE
Bump golang from 1.21.7-alpine3.18 to 1.22.0-alpine3.19

### DIFF
--- a/Dockerfile.gowaves-it
+++ b/Dockerfile.gowaves-it
@@ -1,4 +1,4 @@
-FROM golang:1.21.7-alpine3.18 as builder
+FROM golang:1.22.0-alpine3.19 as builder
 LABEL wavesplatform-gowaves-itests-tmp=true
 WORKDIR /app
 


### PR DESCRIPTION
Bumps golang from 1.21.7-alpine3.18 to 1.22.0-alpine3.19.