### PR TITLE
Add 'cleanup' func for snapshot applier.

### DIFF
--- a/pkg/state/snapshot_applier.go
+++ b/pkg/state/snapshot_applier.go
@@ -367,8 +367,11 @@ func (a *blockSnapshotsApplier) ApplierInfo() extendedSnapshotApplierInfo {
 	return a.info
 }
 
-func (a *blockSnapshotsApplier) SetApplierInfo(info extendedSnapshotApplierInfo) {
+func (a *blockSnapshotsApplier) SetApplierInfo(info extendedSnapshotApplierInfo) func() {
 	a.info = info
+	return func() {
+		a.filterZeroDiffsSHOut(info.BlockID()) // clean up legacy state hash records with zero diffs
+	}
 }
 
 func (a *blockSnapshotsApplier) ApplyWavesBalance(snapshot proto.WavesBalanceSnapshot) error {

--- a/pkg/state/snapshot_generator_internal_test.go
+++ b/pkg/state/snapshot_generator_internal_test.go
@@ -1006,7 +1006,9 @@ func TestDefaultInvokeScriptSnapshot(t *testing.T) {
 	to.activateFeature(t, int16(settings.ReducedNFTFee))
 
 	snapshotApplierInfo := newBlockSnapshotsApplierInfo(info.checkerInfo, to.state.settings.AddressSchemeCharacter)
-	to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	cleanup := to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	defer cleanup()
+
 	fc := proto.NewFunctionCall("call", []proto.Argument{})
 	testData := invokeApplierTestData{
 
@@ -1144,7 +1146,8 @@ func TestNoExtraStaticAssetInfoSnapshot(t *testing.T) {
 	assert.NoError(t, err)
 
 	snapshotApplierInfo := newBlockSnapshotsApplierInfo(info.checkerInfo, to.state.settings.AddressSchemeCharacter)
-	to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	cleanup := to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	defer cleanup()
 
 	fc := proto.NewFunctionCall("call", []proto.Argument{})
 	testData := invokeApplierTestData{
@@ -1244,7 +1247,8 @@ func TestLeaseAndLeaseCancelInTheSameInvokeTx(t *testing.T) {
 	assert.NoError(t, err)
 
 	snapshotApplierInfo := newBlockSnapshotsApplierInfo(info.checkerInfo, to.state.settings.AddressSchemeCharacter)
-	to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	cleanup := to.state.appender.txHandler.sa.SetApplierInfo(snapshotApplierInfo)
+	defer cleanup()
 
 	testData := invokeApplierTestData{
 		payments: []proto.ScriptPayment{},

--- a/pkg/state/tx_snapshot.go
+++ b/pkg/state/tx_snapshot.go
@@ -22,8 +22,7 @@ type extendedSnapshotApplierInfo interface {
 
 type extendedSnapshotApplier interface {
 	ApplierInfo() extendedSnapshotApplierInfo
-	SetApplierInfo(info extendedSnapshotApplierInfo)
-	filterZeroDiffsSHOut(blockID proto.BlockID)
+	SetApplierInfo(info extendedSnapshotApplierInfo) (cleanup func())
 	proto.SnapshotApplier
 	internalSnapshotApplier
 	snapshotApplierHooks


### PR DESCRIPTION
This commit changes the 'extendedSnapshotApplier' interface. Now 'SetApplierInfo' method returns the 'cleanup' closure, which should be called in order to do some cleaning jobs.
Current implementation cleans zero state hash records which have zero diffs.
Cleanup has been also added for `txAppender.validateNextTx` method.