### PR TITLE
Deprecated linter "exportloopref" replaced with "copyloopvar".

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
           args: -c .golangci.yml
       # Strict linter configuration, only checking new code from pull requests.
       - name: golangci-lint-strict
-        run: golangci-lint run -c .golangci-strict.yml --new-from-rev=origin/master --out-format=github-actions,line-number
+        run: golangci-lint run -c .golangci-strict.yml --new-from-rev=origin/master --out-format=colored-line-number
 
   build:
     name: ubuntu

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
           cache: true
 
       - name: Set up GolangCI-Lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $HOME/bin v1.59.0
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $HOME/bin v1.60.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -197,7 +197,6 @@ linters:
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
     - exhaustive # checks exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # forbids identifiers
     - funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
@@ -243,6 +242,7 @@ linters:
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
     - wastedassign # finds wasted assignment statements
     - whitespace # detects leading and trailing whitespace
+    - copyloopvar # detects places where loop variables are copied
 
     ## you may want to enable
     #- decorder # checks declaration order and count of types, constants, variables and functions
@@ -289,7 +289,6 @@ linters:
     #- interfacer # [deprecated] suggests narrower interface types
     #- maligned # [deprecated, replaced by govet fieldalignment] detects Go structs that would take less memory if their fields were sorted
     #- nosnakecase # [deprecated, replaced by revive var-naming] detects snake case of variable naming and function name
-    #- scopelint # [deprecated, replaced by exportloopref] checks for unpinned variables in go programs
     #- structcheck # [deprecated, replaced by unused] finds unused struct fields
     #- varcheck # [deprecated, replaced by unused] finds unused global variables and constants
 


### PR DESCRIPTION
Golangci-lint version updated to v1.60.2.