### PR TITLE
Added work-around to handle the Docker configuration issue

### DIFF
--- a/Dockerfile.gowaves-it
+++ b/Dockerfile.gowaves-it
@@ -55,6 +55,8 @@ CMD /app/node \
     -build-state-hashes \
     -serve-extended-api \
     -log-level=debug \
+    -log-network \
+    -log-fsm \
     -obsolescence=1h \
     -reward=$DESIRED_REWARD \
     -vote=$SUPPORTED_FEATURES \

--- a/itests/docker/docker.go
+++ b/itests/docker/docker.go
@@ -217,9 +217,9 @@ func (d *Docker) runGoNode(ctx context.Context, cfgPath string, suiteName string
 			"SUPPORTED_FEATURES=" + supportedFeatures,
 		},
 		ExposedPorts: []string{
-			GrpcApiPort,
-			RESTApiPort,
-			BindPort,
+			GrpcApiPort + "/tcp",
+			RESTApiPort + "/tcp",
+			BindPort + "/tcp",
 		},
 		Mounts: []string{
 			cfgPath + ":/home/gowaves/config",
@@ -311,9 +311,9 @@ func (d *Docker) runScalaNode(ctx context.Context, cfgPath string, suiteName str
 				"-Dwaves.network.enable-blacklisting=no",
 		},
 		ExposedPorts: []string{
-			GrpcApiPort,
-			RESTApiPort,
-			BindPort,
+			GrpcApiPort + "/tcp",
+			RESTApiPort + "/tcp",
+			BindPort + "/tcp",
 		},
 		Networks: []*dockertest.Network{d.network},
 	}


### PR DESCRIPTION
See https://github.com/moby/moby/issues/48274.

Network and FSM logging turned on for Gowaves node during integration tests.