### PR TITLE
Use 'securego/gosec@5f3194b' action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Run gosec security scanner
-        uses: securego/gosec@v2.21.2
+        uses: securego/gosec@5f3194b581979e508b0ba1ee22f1f1f85a314e16
         with:
           # with '-no-fail' we let the report trigger content trigger a failure using the GitHub Security features.
           args: "-no-fail -fmt sarif -out gosec.sarif ./..."


### PR DESCRIPTION
Use action by commit sha '5f3194b' due to the securego/gosec#1219 issue.