### PR TITLE
Use 'securego/gosec@d4617f5' action.

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Run gosec security scanner
-        uses: securego/gosec@v2.21.3
+        uses: securego/gosec@d4617f51baf75f4f809066386a4f9d27b3ac3e46
         with:
           # with '-no-fail' we let the report trigger content trigger a failure using the GitHub Security features.
           args: "-no-fail -fmt sarif -out gosec.sarif ./..."


### PR DESCRIPTION
Fixes issues with SARIF result uploads.