### PR TITLE
Fix challenged blocks handling.

### DIFF
--- a/pkg/consensus/blocks_validation.go
+++ b/pkg/consensus/blocks_validation.go
@@ -39,7 +39,7 @@ func isInvalidMainNetBlock(blockID proto.BlockID, height uint64) bool {
 type stateInfoProvider interface {
 	HeaderByHeight(height uint64) (*proto.BlockHeader, error)
 	NewestHitSourceAtHeight(height uint64) ([]byte, error)
-	NewestGeneratingBalance(account proto.Recipient, height proto.Height) (uint64, error)
+	NewestMinerGeneratingBalance(header *proto.BlockHeader, height proto.Height) (uint64, error)
 	NewestIsActiveAtHeight(featureID int16, height proto.Height) (bool, error)
 	NewestActivationHeight(featureID int16) (uint64, error)
 	NewestAccountHasScript(addr proto.WavesAddress) (bool, error)
@@ -215,12 +215,7 @@ func (cv *Validator) validateGeneratingBalance(header *proto.BlockHeader, balanc
 }
 
 func (cv *Validator) minerGeneratingBalance(height uint64, header *proto.BlockHeader) (uint64, error) {
-	minerAddr, err := proto.NewAddressFromPublicKey(cv.settings.AddressSchemeCharacter, header.GeneratorPublicKey)
-	if err != nil {
-		return 0, err
-	}
-	account := proto.NewRecipientFromAddress(minerAddr)
-	return cv.state.NewestGeneratingBalance(account, height)
+	return cv.state.NewestMinerGeneratingBalance(header, height)
 }
 
 func (cv *Validator) validBlockVersionAtHeight(blockchainHeight uint64) (proto.BlockVersion, error) {

--- a/pkg/consensus/validator_moq_test.go
+++ b/pkg/consensus/validator_moq_test.go
@@ -27,14 +27,14 @@ var _ stateInfoProvider = &stateInfoProviderMock{}
 //			NewestActivationHeightFunc: func(featureID int16) (uint64, error) {
 //				panic("mock out the NewestActivationHeight method")
 //			},
-//			NewestGeneratingBalanceFunc: func(account proto.Recipient, height uint64) (uint64, error) {
-//				panic("mock out the NewestGeneratingBalance method")
-//			},
 //			NewestHitSourceAtHeightFunc: func(height uint64) ([]byte, error) {
 //				panic("mock out the NewestHitSourceAtHeight method")
 //			},
 //			NewestIsActiveAtHeightFunc: func(featureID int16, height uint64) (bool, error) {
 //				panic("mock out the NewestIsActiveAtHeight method")
+//			},
+//			NewestMinerGeneratingBalanceFunc: func(header *proto.BlockHeader, height uint64) (uint64, error) {
+//				panic("mock out the NewestMinerGeneratingBalance method")
 //			},
 //		}
 //
@@ -52,14 +52,14 @@ type stateInfoProviderMock struct {
 	// NewestActivationHeightFunc mocks the NewestActivationHeight method.
 	NewestActivationHeightFunc func(featureID int16) (uint64, error)
 
-	// NewestGeneratingBalanceFunc mocks the NewestGeneratingBalance method.
-	NewestGeneratingBalanceFunc func(account proto.Recipient, height uint64) (uint64, error)
-
 	// NewestHitSourceAtHeightFunc mocks the NewestHitSourceAtHeight method.
 	NewestHitSourceAtHeightFunc func(height uint64) ([]byte, error)
 
 	// NewestIsActiveAtHeightFunc mocks the NewestIsActiveAtHeight method.
 	NewestIsActiveAtHeightFunc func(featureID int16, height uint64) (bool, error)
+
+	// NewestMinerGeneratingBalanceFunc mocks the NewestMinerGeneratingBalance method.
+	NewestMinerGeneratingBalanceFunc func(header *proto.BlockHeader, height uint64) (uint64, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -78,13 +78,6 @@ type stateInfoProviderMock struct {
 			// FeatureID is the featureID argument value.
 			FeatureID int16
 		}
-		// NewestGeneratingBalance holds details about calls to the NewestGeneratingBalance method.
-		NewestGeneratingBalance []struct {
-			// Account is the account argument value.
-			Account proto.Recipient
-			// Height is the height argument value.
-			Height uint64
-		}
 		// NewestHitSourceAtHeight holds details about calls to the NewestHitSourceAtHeight method.
 		NewestHitSourceAtHeight []struct {
 			// Height is the height argument value.
@@ -97,13 +90,20 @@ type stateInfoProviderMock struct {
 			// Height is the height argument value.
 			Height uint64
 		}
+		// NewestMinerGeneratingBalance holds details about calls to the NewestMinerGeneratingBalance method.
+		NewestMinerGeneratingBalance []struct {
+			// Header is the header argument value.
+			Header *proto.BlockHeader
+			// Height is the height argument value.
+			Height uint64
+		}
 	}
-	lockHeaderByHeight          sync.RWMutex
-	lockNewestAccountHasScript  sync.RWMutex
-	lockNewestActivationHeight  sync.RWMutex
-	lockNewestGeneratingBalance sync.RWMutex
-	lockNewestHitSourceAtHeight sync.RWMutex
-	lockNewestIsActiveAtHeight  sync.RWMutex
+	lockHeaderByHeight               sync.RWMutex
+	lockNewestAccountHasScript       sync.RWMutex
+	lockNewestActivationHeight       sync.RWMutex
+	lockNewestHitSourceAtHeight      sync.RWMutex
+	lockNewestIsActiveAtHeight       sync.RWMutex
+	lockNewestMinerGeneratingBalance sync.RWMutex
 }
 
 // HeaderByHeight calls HeaderByHeightFunc.
@@ -202,42 +202,6 @@ func (mock *stateInfoProviderMock) NewestActivationHeightCalls() []struct {
 	return calls
 }
 
-// NewestGeneratingBalance calls NewestGeneratingBalanceFunc.
-func (mock *stateInfoProviderMock) NewestGeneratingBalance(account proto.Recipient, height uint64) (uint64, error) {
-	if mock.NewestGeneratingBalanceFunc == nil {
-		panic("stateInfoProviderMock.NewestGeneratingBalanceFunc: method is nil but stateInfoProvider.NewestGeneratingBalance was just called")
-	}
-	callInfo := struct {
-		Account proto.Recipient
-		Height  uint64
-	}{
-		Account: account,
-		Height:  height,
-	}
-	mock.lockNewestGeneratingBalance.Lock()
-	mock.calls.NewestGeneratingBalance = append(mock.calls.NewestGeneratingBalance, callInfo)
-	mock.lockNewestGeneratingBalance.Unlock()
-	return mock.NewestGeneratingBalanceFunc(account, height)
-}
-
-// NewestGeneratingBalanceCalls gets all the calls that were made to NewestGeneratingBalance.
-// Check the length with:
-//
-//	len(mockedstateInfoProvider.NewestGeneratingBalanceCalls())
-func (mock *stateInfoProviderMock) NewestGeneratingBalanceCalls() []struct {
-	Account proto.Recipient
-	Height  uint64
-} {
-	var calls []struct {
-		Account proto.Recipient
-		Height  uint64
-	}
-	mock.lockNewestGeneratingBalance.RLock()
-	calls = mock.calls.NewestGeneratingBalance
-	mock.lockNewestGeneratingBalance.RUnlock()
-	return calls
-}
-
 // NewestHitSourceAtHeight calls NewestHitSourceAtHeightFunc.
 func (mock *stateInfoProviderMock) NewestHitSourceAtHeight(height uint64) ([]byte, error) {
 	if mock.NewestHitSourceAtHeightFunc == nil {
@@ -303,5 +267,41 @@ func (mock *stateInfoProviderMock) NewestIsActiveAtHeightCalls() []struct {
 	mock.lockNewestIsActiveAtHeight.RLock()
 	calls = mock.calls.NewestIsActiveAtHeight
 	mock.lockNewestIsActiveAtHeight.RUnlock()
+	return calls
+}
+
+// NewestMinerGeneratingBalance calls NewestMinerGeneratingBalanceFunc.
+func (mock *stateInfoProviderMock) NewestMinerGeneratingBalance(header *proto.BlockHeader, height uint64) (uint64, error) {
+	if mock.NewestMinerGeneratingBalanceFunc == nil {
+		panic("stateInfoProviderMock.NewestMinerGeneratingBalanceFunc: method is nil but stateInfoProvider.NewestMinerGeneratingBalance was just called")
+	}
+	callInfo := struct {
+		Header *proto.BlockHeader
+		Height uint64
+	}{
+		Header: header,
+		Height: height,
+	}
+	mock.lockNewestMinerGeneratingBalance.Lock()
+	mock.calls.NewestMinerGeneratingBalance = append(mock.calls.NewestMinerGeneratingBalance, callInfo)
+	mock.lockNewestMinerGeneratingBalance.Unlock()
+	return mock.NewestMinerGeneratingBalanceFunc(header, height)
+}
+
+// NewestMinerGeneratingBalanceCalls gets all the calls that were made to NewestMinerGeneratingBalance.
+// Check the length with:
+//
+//	len(mockedstateInfoProvider.NewestMinerGeneratingBalanceCalls())
+func (mock *stateInfoProviderMock) NewestMinerGeneratingBalanceCalls() []struct {
+	Header *proto.BlockHeader
+	Height uint64
+} {
+	var calls []struct {
+		Header *proto.BlockHeader
+		Height uint64
+	}
+	mock.lockNewestMinerGeneratingBalance.RLock()
+	calls = mock.calls.NewestMinerGeneratingBalance
+	mock.lockNewestMinerGeneratingBalance.RUnlock()
 	return calls
 }

--- a/pkg/state/balances.go
+++ b/pkg/state/balances.go
@@ -137,14 +137,6 @@ func (c *challengedAddressRecord) appendHeight(height proto.Height) {
 	}
 }
 
-type challengerAddressRecord struct {
-	Bonus uint64 `cbor:"0,keyasint"`
-}
-
-func (c *challengerAddressRecord) marshalBinary() ([]byte, error) { return cbor.Marshal(c) }
-
-func (c *challengerAddressRecord) unmarshalBinary(data []byte) error { return cbor.Unmarshal(data, c) }
-
 type leaseBalanceRecordForHashes struct {
 	addr     *proto.WavesAddress
 	leaseIn  int64
@@ -616,81 +608,43 @@ func (s *balances) generatingBalance(addr proto.AddressID, height proto.Height) 
 	startHeight, endHeight := s.sets.RangeForGeneratingBalanceByHeight(height)
 	gb, err := s.minEffectiveBalanceInRange(addr, startHeight, endHeight)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed get min effective balance; startHeight %d, endHeight %d",
+		return 0, errors.Wrapf(err, "failed to get min effective balance with startHeight %d and endHeight %d",
 			startHeight, endHeight)
 	}
-	bonus, err := s.challengerBonus(addr, height)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed get challenger bonus at height %d", height)
-	}
-	r, err := common.AddInt(gb, bonus)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to add generating balance and bonus")
-	}
-	return r, nil
+	return gb, nil
 }
 
 func (s *balances) newestGeneratingBalance(addr proto.AddressID, height proto.Height) (uint64, error) {
 	startHeight, endHeight := s.sets.RangeForGeneratingBalanceByHeight(height)
 	gb, err := s.newestMinEffectiveBalanceInRange(addr, startHeight, endHeight)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed get newest min effective balance with startHeight %d and endHeight %d",
+		return 0, errors.Wrapf(err, "failed to get newest min effective balance with startHeight %d and endHeight %d",
 			startHeight, endHeight)
 	}
-	bonus, err := s.newestChallengerBonus(addr, height)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed get newest challenger bonus at height %d", height)
-	}
-	r, err := common.AddInt(gb, bonus)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to add generating balance and bonus")
-	}
-	return r, nil
+	return gb, nil
 }
 
 func (s *balances) storeChallenge(
 	challenger, challenged proto.AddressID,
-	blockchainHeight proto.Height, // for changing generating balance we use current blockchain height
+	challengedBlockHeight proto.Height, // Height of the block with the challenged header.
 	blockID proto.BlockID,
 ) error {
 	// Check if challenger and challenged addresses are the same. Self-challenge is not allowed.
 	if challenger.Equal(challenged) {
 		return errors.New("challenger and challenged addresses are the same")
 	}
-	// Get challenger bonus before storing the challenged penalty.
-	// Challenged can't be with bonus and be challenged at the same height because of the check above.
-	generatingBalance, gbErr := s.newestGeneratingBalance(challenged, blockchainHeight)
-	if gbErr != nil {
-		return errors.Wrapf(gbErr, "failed to get generating balance for challenged address at height %d", blockchainHeight)
-	}
-	if err := s.storeChallengeBonusForAddr(challenger, generatingBalance, blockchainHeight, blockID); err != nil {
-		return errors.Wrapf(err, "failed to store challenge bonus for challenger at height %d", blockchainHeight)
-	}
-	if err := s.storeChallengeHeightForAddr(challenged, blockchainHeight, blockID); err != nil {
-		return errors.Wrapf(err, "failed to store challenge height for challenged at height %d", blockchainHeight)
+	if err := s.storeChallengeHeightForAddr(challenged, challengedBlockHeight, blockID); err != nil {
+		return errors.Wrapf(err, "failed to store challenge height for challenged at height %d",
+			challengedBlockHeight,
+		)
 	}
 	return nil
-}
-
-func (s *balances) storeChallengeBonusForAddr(
-	challenger proto.AddressID,
-	bonus uint64,
-	height proto.Height,
-	blockID proto.BlockID,
-) error {
-	r := challengerAddressRecord{Bonus: bonus}
-	recordBytes, mErr := r.marshalBinary()
-	if mErr != nil {
-		return errors.Wrap(mErr, "failed to marshal record to binary data")
-	}
-	key := challengerAddressKey{address: challenger, height: height}
-	return s.hs.addNewEntry(challengerAddress, key.bytes(), recordBytes, blockID)
 }
 
 // storeChallengeHeightForAddr stores the height of the block at which the address was challenged.
 func (s *balances) storeChallengeHeightForAddr(
 	challenged proto.AddressID,
-	height proto.Height,
+	challengedBlockHeight proto.Height,
 	blockID proto.BlockID,
 ) error {
 	key := challengedAddressKey{address: challenged}
@@ -698,7 +652,7 @@ func (s *balances) storeChallengeHeightForAddr(
 	recordBytes, err := s.hs.newestTopEntryData(keyBytes)
 	if err != nil {
 		if isNotFoundInHistoryOrDBErr(err) { // No record found, create new one.
-			r := challengedAddressRecord{Heights: []proto.Height{height}}
+			r := challengedAddressRecord{Heights: []proto.Height{challengedBlockHeight}}
 			data, mErr := r.marshalBinary()
 			if mErr != nil {
 				return errors.Wrap(err, "failed to marshal record to binary data")
@@ -711,7 +665,7 @@ func (s *balances) storeChallengeHeightForAddr(
 	if uErr := r.unmarshalBinary(recordBytes); uErr != nil {
 		return errors.Wrap(err, "failed to unmarshal record from binary data")
 	}
-	r.appendHeight(height) // Append new height to the list.
+	r.appendHeight(challengedBlockHeight) // Append new height to the list.
 	recordBytes, err = r.marshalBinary()
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal record to binary data")
@@ -751,30 +705,6 @@ func isChallengedAddressInRangeCommon(
 		}
 	}
 	return false, nil
-}
-
-func getChallengerBonusCommon(getEntryData entryDataGetter, addr proto.AddressID, height proto.Height) (uint64, error) {
-	key := challengerAddressKey{address: addr, height: height}
-	recordBytes, err := getEntryData(key.bytes())
-	if err != nil {
-		if isNotFoundInHistoryOrDBErr(err) { // No challenger record found, return 0.
-			return 0, nil
-		}
-		return 0, err
-	}
-	var r challengerAddressRecord
-	if ubErr := r.unmarshalBinary(recordBytes); ubErr != nil {
-		return 0, errors.Wrap(ubErr, "failed to unmarshal record from binary data")
-	}
-	return r.Bonus, nil
-}
-
-func (s *balances) challengerBonus(addr proto.AddressID, height proto.Height) (uint64, error) {
-	return getChallengerBonusCommon(s.hs.topEntryData, addr, height)
-}
-
-func (s *balances) newestChallengerBonus(addr proto.AddressID, height proto.Height) (uint64, error) {
-	return getChallengerBonusCommon(s.hs.newestTopEntryData, addr, height)
 }
 
 func (s *balances) isChallengedAddressInRange(addr proto.AddressID, startHeight, endHeight proto.Height) (bool, error) {

--- a/pkg/state/balances_test.go
+++ b/pkg/state/balances_test.go
@@ -330,12 +330,15 @@ func TestBalancesChangesByStoredChallenge(t *testing.T) {
 			{firstBlock, challengerID, 1},
 			// because lastBlockBeforeChallenge1 == generationBalanceDepthDiff, so we use the lowes value in the range
 			{lastBlockBeforeChallenge1, challengerID, 1},
-			// challengerGenBalance + challengedGenBalance = 1 + 1
-			{challengeHeight1, challengerID, 2 * (challengeHeight1 - generationBalanceDepthDiff)},
+			// challengerGenBalance = 1 , i.e. without challenger bonus, bonus MUST be included in generation balance
+			// only for block header validation, but not for generating balance.
+			// See 'stateManager.NewestMinerGeneratingBalance' and its usages for more info.
+			{challengeHeight1, challengerID, challengeHeight1 - generationBalanceDepthDiff},
 			{firstBlockAfterChallenge1, challengerID, firstBlockAfterChallenge1 - generationBalanceDepthDiff},
 			{lastBlockBeforeChallenge2, challengerID, lastBlockBeforeChallenge2 - generationBalanceDepthDiff},
-			// challengerGenBalance + challengedGenBalance = 51 + 51
-			{challengeHeight2, challengerID, 2 * (challengeHeight2 - generationBalanceDepthDiff)},
+			// challengerGenBalance = 51
+			// See comment above for the explanation why challenger bonus is not included in generating balance.
+			{challengeHeight2, challengerID, challengeHeight2 - generationBalanceDepthDiff},
 			{firstBlockAfterChallenge2, challengerID, firstBlockAfterChallenge2 - generationBalanceDepthDiff},
 			{totalBlocksNumber, challengerID, totalBlocksNumber - generationBalanceDepthDiff},
 			// FOR CHALLENGED

--- a/pkg/state/constants.go
+++ b/pkg/state/constants.go
@@ -25,7 +25,7 @@ const (
 
 	// StateVersion is current version of state internal storage formats.
 	// It increases when backward compatibility with previous storage version is lost.
-	StateVersion = 25
+	StateVersion = 26
 
 	// Memory limit for address transactions. flush() is called when this
 	// limit is exceeded.

--- a/pkg/state/history_storage.go
+++ b/pkg/state/history_storage.go
@@ -45,7 +45,6 @@ const (
 	snapshots
 	patches
 	challengedAddress
-	challengerAddress
 )
 
 type blockchainEntityProperties struct {
@@ -209,11 +208,6 @@ var properties = map[blockchainEntity]blockchainEntityProperties{
 		fixedSize:    false,
 	},
 	challengedAddress: {
-		needToFilter: true,
-		needToCut:    true,
-		fixedSize:    false,
-	},
-	challengerAddress: {
 		needToFilter: true,
 		needToCut:    true,
 		fixedSize:    false,

--- a/pkg/state/keys.go
+++ b/pkg/state/keys.go
@@ -30,7 +30,6 @@ const (
 	snapshotKeySize          = 1 + 8
 	rewardVotesKeySize       = 1 + 8
 	challengedAddressKeySize = 1 + proto.AddressIDSize
-	challengerAddressKeySize = 1 + proto.AddressIDSize + uint64Size
 )
 
 // Primary prefixes for storage keys
@@ -136,7 +135,6 @@ const (
 	patchKeyPrefix
 
 	challengedAddressKeyPrefix
-	challengerAddressKeyPrefix
 )
 
 var (
@@ -202,8 +200,6 @@ func prefixByEntity(entity blockchainEntity) ([]byte, error) {
 		return []byte{patchKeyPrefix}, nil
 	case challengedAddress:
 		return []byte{challengedAddressKeyPrefix}, nil
-	case challengerAddress:
-		return []byte{challengerAddressKeyPrefix}, nil
 	default:
 		return nil, errors.New("bad entity type")
 	}
@@ -763,18 +759,5 @@ func (k *challengedAddressKey) bytes() []byte {
 	buf := make([]byte, challengedAddressKeySize)
 	buf[0] = challengedAddressKeyPrefix
 	copy(buf[1:], k.address[:])
-	return buf
-}
-
-type challengerAddressKey struct {
-	address proto.AddressID
-	height  proto.Height
-}
-
-func (k *challengerAddressKey) bytes() []byte {
-	buf := make([]byte, challengerAddressKeySize)
-	buf[0] = challengerAddressKeyPrefix
-	copy(buf[1:], k.address[:])
-	binary.BigEndian.PutUint64(buf[1+proto.AddressIDSize:], k.height)
 	return buf
 }


### PR DESCRIPTION
This PR **breaks compatibility** with the previous state version.
Fix for #1423.
The challenger’s bonus is now only considered during block header validation. The effective balance of the challenged is now reset at the block height with the "challenge".