### PR TITLE
Remove invalid NTP server address from itest scala config to get rid …

### DIFF
--- a/itests/config/template.conf
+++ b/itests/config/template.conf
@@ -1,7 +1,7 @@
 waves {
   blockchain.type = CUSTOM
   directory = /var/lib/waves
-  ntp-server = "localhost:123"
+  ntp-server = ""
   db {
     store-state-hashes = true
   }


### PR DESCRIPTION
…of NTP errors in scala logs.