### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/pkg/state/transaction_checker.go
+++ b/pkg/state/transaction_checker.go
@@ -894,7 +894,7 @@ func (tc *transactionChecker) checkExchange(transaction proto.Transaction, info 
 	}
 	txa := &txAssets{feeAsset: proto.NewOptionalAssetWaves(), smartAssets: ordersSmartAssets}
 	if errCF := tc.checkFee(transaction, txa, info); errCF != nil {
-		return nil, err
+		return nil, errCF
 	}
 	smartAssetsActivated, err := tc.stor.features.newestIsActivated(int16(settings.SmartAssets))
 	if err != nil {


### PR DESCRIPTION
Because err has been checked before and return as != nil.

Err here must be nil, and `errCF` should actually be return.