### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/itests/burn_tx_api_internal_test.go
+++ b/itests/burn_tx_api_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"testing"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type BurnTxApiSuite struct {

--- a/itests/burn_tx_internal_test.go
+++ b/itests/burn_tx_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type BurnTxSuite struct {

--- a/itests/reissue_tx_api_internal_test.go
+++ b/itests/reissue_tx_api_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/reissue"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type ReissueTxApiSuite struct {

--- a/itests/reissuie_tx_internal_test.go
+++ b/itests/reissuie_tx_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -13,7 +14,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/reissue"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type ReissueTxSuite struct {

--- a/itests/smoke_tx_api_positive_internal_test.go
+++ b/itests/smoke_tx_api_positive_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -18,7 +19,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/sponsorship"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/itests/utilities/updateassetinfo"
-	"golang.org/x/exp/maps"
 )
 
 type SmokeTxApiPositiveSuite struct {

--- a/itests/smoke_tx_positive_internal_test.go
+++ b/itests/smoke_tx_positive_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -18,7 +19,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/sponsorship"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/itests/utilities/updateassetinfo"
-	"golang.org/x/exp/maps"
 )
 
 type SmokeTxPositiveSuite struct {

--- a/itests/testdata/update_asset_info_testdata.go
+++ b/itests/testdata/update_asset_info_testdata.go
@@ -1,12 +1,13 @@
 package testdata
 
 import (
+	"maps"
+
 	"github.com/wavesplatform/gowaves/itests/config"
 	f "github.com/wavesplatform/gowaves/itests/fixtures"
 	utl "github.com/wavesplatform/gowaves/itests/utilities"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/proto"
-	"golang.org/x/exp/maps"
 )
 
 const (

--- a/itests/transfer_tx_api_internal_test.go
+++ b/itests/transfer_tx_api_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type TransferTxApiSuite struct {

--- a/itests/transfer_tx_internal_test.go
+++ b/itests/transfer_tx_internal_test.go
@@ -4,6 +4,7 @@ package itests
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,6 @@ import (
 	"github.com/wavesplatform/gowaves/itests/utilities/issue"
 	"github.com/wavesplatform/gowaves/itests/utilities/transfer"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
-	"golang.org/x/exp/maps"
 )
 
 type TransferTxSuite struct {

--- a/pkg/ride/compiler/compaction.go
+++ b/pkg/ride/compiler/compaction.go
@@ -1,9 +1,10 @@
 package compiler
 
 import (
+	"maps"
+
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
 	"github.com/wavesplatform/gowaves/pkg/ride/meta"
-	"golang.org/x/exp/maps"
 )
 
 const (


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.