### PR TITLE
Replace deprecated 'golang.org/x/exp/rand' to 'math/rand/v2'

### DIFF
--- a/pkg/node/peers/score_selector.go
+++ b/pkg/node/peers/score_selector.go
@@ -157,7 +157,7 @@ func (s *scoreSelector) selectBestPeer(currentBest peer.ID) (peer.ID, *proto.Sco
 		}
 		// The peer was not found in the larges group, time to change the peer.
 		// Select the random peer from the group and return it along with a new score value.
-		i := rand.IntN(len(g.peers))
+		i := rand.IntN(len(g.peers)) // #nosec: it's ok to use math/rand/v2 here
 		heap.Push(s.groups, g)
 		return g.peers[i], g.score
 	}

--- a/pkg/node/peers/score_selector.go
+++ b/pkg/node/peers/score_selector.go
@@ -3,8 +3,7 @@ package peers
 import (
 	"container/heap"
 	"fmt"
-
-	"golang.org/x/exp/rand"
+	"math/rand/v2"
 
 	"github.com/wavesplatform/gowaves/pkg/p2p/peer"
 	"github.com/wavesplatform/gowaves/pkg/proto"
@@ -158,7 +157,7 @@ func (s *scoreSelector) selectBestPeer(currentBest peer.ID) (peer.ID, *proto.Sco
 		}
 		// The peer was not found in the larges group, time to change the peer.
 		// Select the random peer from the group and return it along with a new score value.
-		i := rand.Intn(len(g.peers))
+		i := rand.IntN(len(g.peers))
 		heap.Push(s.groups, g)
 		return g.peers[i], g.score
 	}


### PR DESCRIPTION
For more info see https://go.dev/issue/61716.