### PR TITLE
Exclude 'gitlab.gosec' ruleset from semgrep CI job.

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cat << 'EOF' | bash
               semgrep ci --config="auto" --config="r/default" --config="r/go" --config="r/dgryski" \
-                --config="r/trailofbits" --config="r/gitlab.gosec" --config="r/dockerfile" --config="r/bash" \
+                --config="r/trailofbits" --config="r/dockerfile" --config="r/bash" \
                 --config="r/problem-based-packs" --config="r/generic" --config="r/yaml" --config="r/json" \
                 --sarif --dataflow-traces --output=semgrep.sarif --max-target-bytes=2MB
               EXIT_CODE=$?


### PR DESCRIPTION
Excluded because rules in this ruleset contain 'security-severity' field with a string type value, while SARIF format accepts only numerical. For more info see https://github.com/semgrep/semgrep/issues/10834.