### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/itests/utilities/common.go
+++ b/itests/utilities/common.go
@@ -404,10 +404,7 @@ func GetHeight(suite *f.BaseSuite) uint64 {
 	}()
 	goHeight := <-goCh
 	scalaHeight := <-scalaCh
-	if goHeight < scalaHeight {
-		return goHeight
-	}
-	return scalaHeight
+	return min(scalaHeight, goHeight)
 }
 
 func WaitForHeight(suite *f.BaseSuite, height uint64) uint64 {


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max