### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/node/peers/spawner.go
+++ b/pkg/node/peers/spawner.go
@@ -3,6 +3,7 @@ package peers
 import (
 	"context"
 	"net"
+	"slices"
 
 	"github.com/wavesplatform/gowaves/pkg/node/messages"
 	"github.com/wavesplatform/gowaves/pkg/p2p/conn"
@@ -19,12 +20,7 @@ type DuplicateChecker interface {
 func NewSkipFilter(list *messages.SkipMessageList) conn.SkipFilter {
 	return func(header proto.Header) bool {
 		return func(h proto.Header, l *messages.SkipMessageList) bool {
-			for _, id := range l.List() {
-				if h.ContentID == id {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(l.List(), h.ContentID)
 		}(header, list)
 	}
 }

--- a/pkg/proto/eth_typed_data.go
+++ b/pkg/proto/eth_typed_data.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -93,12 +94,7 @@ func (typedData *ethereumTypedData) HashStructMap(primaryType string,
 // Dependencies returns an array of custom types ordered by their hierarchical reference tree
 func (typedData *ethereumTypedData) Dependencies(primaryType string, found []string) []string {
 	includes := func(arr []string, str string) bool {
-		for _, obj := range arr {
-			if obj == str {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(arr, str)
 	}
 
 	if includes(found, primaryType) {

--- a/pkg/ride/compiler/compaction.go
+++ b/pkg/ride/compiler/compaction.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
 	"github.com/wavesplatform/gowaves/pkg/ride/meta"
@@ -93,12 +94,7 @@ func (c *Compaction) replaceName(oldName string) string {
 }
 
 func (c *Compaction) contains(oldName string) bool {
-	for _, n := range c.knownDecs {
-		if n == oldName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.knownDecs, oldName)
 }
 
 func (c *Compaction) getReplacedName(oldName string) string {

--- a/pkg/ride/compiler/stdlib/types.go
+++ b/pkg/ride/compiler/stdlib/types.go
@@ -2,6 +2,7 @@ package stdlib
 
 import (
 	"encoding/json"
+	"slices"
 	"sort"
 	"strings"
 
@@ -291,13 +292,7 @@ func (t *UnionType) AppendType(rideType Type) {
 				t.Types = append(t.Types, newType)
 				continue
 			}
-			exist := false
-			for _, existType := range t.Types {
-				if newType.Equal(existType) {
-					exist = true
-					break
-				}
-			}
+			exist := slices.ContainsFunc(t.Types, newType.Equal)
 			if !exist {
 				if _, ok := newType.(ListType); ok && listExist {
 					list := t.Types[listIndex].(ListType)

--- a/pkg/ride/functions_proto.go
+++ b/pkg/ride/functions_proto.go
@@ -7,6 +7,7 @@ import (
 	sh256 "crypto/sha256"
 	"crypto/x509"
 	"math/big"
+	"slices"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/mr-tron/base58"
@@ -28,12 +29,7 @@ const (
 )
 
 func containsAddress(addr proto.WavesAddress, list []proto.WavesAddress) bool {
-	for _, v := range list {
-		if v == addr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, addr)
 }
 
 func extractOptionalAsset(v rideType) (proto.OptionalAsset, error) {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.