### PR TITLE
Fix empty bind address with enhancements in entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,5 +6,5 @@ if [ $# -eq 0 ]; then
   exec /app/node "$@"
 else
   # Merge CMD + user-provided args
-  exec /app/node "$@" "-state-path=/home/gowaves/state" "-bind-address=0.0.0.0:6868" "-api-address=0.0.0.0:6869" "-build-extended-api" "-serve-extended-api" "-build-state-hashes" "-enable-grpc-api" "-grpc-address=0.0.0.0:7470"
+  exec /app/node "-state-path=/home/gowaves/state" "-bind-address=0.0.0.0:6868" "-api-address=0.0.0.0:6869" "-build-extended-api" "-serve-extended-api" "-build-state-hashes" "-enable-grpc-api" "-grpc-address=0.0.0.0:7470" "$@"
 fi

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -53,8 +53,8 @@ func NewNode(
 	services services.Services, declAddr proto.TCPAddr, bindAddr proto.TCPAddr, microblockInterval time.Duration,
 	enableLightMode bool,
 ) *Node {
-	if bindAddr.Empty() && bindAddr.Port == 0 {
-		zap.S().Warnf("BindAddr is empty, using declared address %q", declAddr.String())
+	if bindAddr.EmptyNoPort() {
+		zap.S().Warnf("Bind IP address and port are empty, using declared address %q", declAddr.String())
 		bindAddr = declAddr
 	}
 	return &Node{
@@ -94,12 +94,12 @@ func (a *Node) serveIncomingPeers(ctx context.Context) error {
 
 	// if empty declared address, listen on port doesn't make sense
 	if a.declAddr.Empty() {
-		zap.S().Warn("Declared address is empty")
+		zap.S().Warn("Declared IP address is empty")
 		return nil
 	}
 
-	if a.bindAddr.Empty() {
-		zap.S().Warn("Bind address is empty")
+	if a.bindAddr.EmptyNoPort() {
+		zap.S().Warn("Bind IP address and port are empty")
 		return nil
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -53,7 +53,7 @@ func NewNode(
 	services services.Services, declAddr proto.TCPAddr, bindAddr proto.TCPAddr, microblockInterval time.Duration,
 	enableLightMode bool,
 ) *Node {
-	if bindAddr.Empty() {
+	if bindAddr.Empty() && bindAddr.Port == 0 {
 		zap.S().Warnf("BindAddr is empty, using declared address %q", declAddr.String())
 		bindAddr = declAddr
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -54,6 +54,7 @@ func NewNode(
 	enableLightMode bool,
 ) *Node {
 	if bindAddr.Empty() {
+		zap.S().Warnf("BindAddr is empty, using declared address %q", declAddr.String())
 		bindAddr = declAddr
 	}
 	return &Node{

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -591,7 +591,7 @@ func (a TCPAddr) String() string {
 	return net.JoinHostPort(a.IP.String(), strconv.Itoa(a.Port))
 }
 
-// Empty checks if IP of TCPAddr is empty.
+// Empty checks if IP of TCPAddr is empty or unspecified (e.g., 0.0.0.0 or ::).
 func (a TCPAddr) Empty() bool {
 	return len(a.IP) == 0 || a.IP.IsUnspecified()
 }

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -899,7 +899,7 @@ func filterToIPV4(ips []net.IP) []net.IP {
 
 func resolveHostToIPsv4(host string) ([]net.IP, error) {
 	if host == "" {
-		host = "0.0.0.0" // set default host to
+		host = "0.0.0.0" // set default host to 0.0.0.0
 	}
 	if ip := net.ParseIP(host); ip != nil { // try to parse host as IP address
 		ipV4 := ip.To4() // try to convert to IPv4

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -591,8 +591,14 @@ func (a TCPAddr) String() string {
 	return net.JoinHostPort(a.IP.String(), strconv.Itoa(a.Port))
 }
 
+// Empty checks if IP of TCPAddr is empty.
 func (a TCPAddr) Empty() bool {
 	return len(a.IP) == 0 || a.IP.IsUnspecified()
+}
+
+// EmptyNoPort checks if IP of TCPAddr is empty AND port is 0.
+func (a TCPAddr) EmptyNoPort() bool {
+	return a.Empty() && a.Port == 0
 }
 
 func (a TCPAddr) WriteTo(w io.Writer) (int64, error) {

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -898,6 +898,9 @@ func filterToIPV4(ips []net.IP) []net.IP {
 }
 
 func resolveHostToIPsv4(host string) ([]net.IP, error) {
+	if host == "" {
+		host = "0.0.0.0" // set default host to
+	}
 	if ip := net.ParseIP(host); ip != nil { // try to parse host as IP address
 		ipV4 := ip.To4() // try to convert to IPv4
 		if ipV4 == nil {

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -770,7 +770,6 @@ func TestTCPAddr_EmptyNoPort(t *testing.T) {
 		{NewTCPAddrFromString(":6868"), false}, // no host is specified, host by default is 0.0.0.0
 		{NewTCPAddrFromString("0.0.0.0:6868"), false},
 		{NewTCPAddrFromString("127.0.0.1:6868"), false},
-		{NewTCPAddrFromString("127.0.0.1:6868"), false},
 		{NewTCPAddrFromString("0.0.0.0:0"), true},
 		{NewTCPAddrFromString("127.0.0.1"), true}, // no port, returns empty
 		{NewTCPAddrFromString("fooo"), true},      // invalid address, returns empty

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -751,7 +751,6 @@ func TestTCPAddr_Empty(t *testing.T) {
 		{NewTCPAddrFromString("0.0.0.0:6868"), true},
 		{NewTCPAddrFromString("0.0.0.0:0"), true},
 		{NewTCPAddrFromString("127.0.0.1:6868"), false},
-		{NewTCPAddrFromString("127.0.0.1:6868"), false},
 		{NewTCPAddrFromString("127.0.0.1"), true}, // no port, returns empty
 		{NewTCPAddrFromString("fooo"), true},      // invalid address, returns empty
 		{NewTCPAddrFromString(":6868"), true},     // no host is specified, returns empty

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -742,3 +742,8 @@ func TestChecksumReader(t *testing.T) {
 		})
 	}
 }
+
+func TestTCPAddr_Empty(t *testing.T) {
+	addr := NewTCPAddrFromString("0.0.0.0:6868")
+	require.True(t, addr.Empty())
+}

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -744,6 +744,42 @@ func TestChecksumReader(t *testing.T) {
 }
 
 func TestTCPAddr_Empty(t *testing.T) {
-	addr := NewTCPAddrFromString("0.0.0.0:6868")
-	require.True(t, addr.Empty())
+	tcs := []struct {
+		addr  TCPAddr
+		empty bool
+	}{
+		{NewTCPAddrFromString("0.0.0.0:6868"), true},
+		{NewTCPAddrFromString("0.0.0.0:0"), true},
+		{NewTCPAddrFromString("127.0.0.1:6868"), false},
+		{NewTCPAddrFromString("127.0.0.1:6868"), false},
+		{NewTCPAddrFromString("127.0.0.1"), true}, // no port, returns empty
+		{NewTCPAddrFromString("fooo"), true},      // invalid address, returns empty
+		{NewTCPAddrFromString(":6868"), true},     // no host is specified, returns empty
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
+			assert.Equal(t, tc.empty, tc.addr.Empty())
+		})
+	}
+}
+
+func TestTCPAddr_EmptyNoPort(t *testing.T) {
+	tcs := []struct {
+		addr  TCPAddr
+		empty bool
+	}{
+		{NewTCPAddrFromString("0.0.0.0:6868"), false},
+		{NewTCPAddrFromString("127.0.0.1:6868"), false},
+		{NewTCPAddrFromString("127.0.0.1:6868"), false},
+		{NewTCPAddrFromString("0.0.0.0:0"), true},
+		{NewTCPAddrFromString("127.0.0.1"), true}, // no port, returns empty
+		{NewTCPAddrFromString("fooo"), true},      // invalid address, returns empty
+		{NewTCPAddrFromString(":6868"), true},     // no host is specified, returns empty
+
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
+			assert.Equal(t, tc.empty, tc.addr.EmptyNoPort())
+		})
+	}
 }

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -768,13 +768,13 @@ func TestTCPAddr_EmptyNoPort(t *testing.T) {
 		addr  TCPAddr
 		empty bool
 	}{
+		{NewTCPAddrFromString(":6868"), false}, // no host is specified, host by default is 0.0.0.0
 		{NewTCPAddrFromString("0.0.0.0:6868"), false},
 		{NewTCPAddrFromString("127.0.0.1:6868"), false},
 		{NewTCPAddrFromString("127.0.0.1:6868"), false},
 		{NewTCPAddrFromString("0.0.0.0:0"), true},
 		{NewTCPAddrFromString("127.0.0.1"), true}, // no port, returns empty
 		{NewTCPAddrFromString("fooo"), true},      // invalid address, returns empty
-		{NewTCPAddrFromString(":6868"), true},     // no host is specified, returns empty
 
 	}
 	for i, tc := range tcs {


### PR DESCRIPTION
This pull request introduces enhancements to address validation and logging in the `Node` and `TCPAddr` components, along with corresponding unit tests for the new functionality. The key changes include adding a new method to check if both IP and port are empty, improving logging messages, and setting a default host when resolving empty addresses.

### Enhancements to `TCPAddr` validation:

* Added a new method `EmptyNoPort` in `TCPAddr` to check if both the IP address is unspecified and the port is 0. This complements the existing `Empty` method. (`pkg/proto/proto.go`, [pkg/proto/proto.go:R594-R603](diffhunk://#diff-9414ee6fc81d60fc74df47fe91c3f51c820bf236c091908007209a3583b174cdR594-R603))

* Updated the `resolveHostToIPsv4` function to set the default host to `0.0.0.0` if the provided host is empty. (`pkg/proto/proto.go`, [pkg/proto/proto.go:R901-R903](diffhunk://#diff-9414ee6fc81d60fc74df47fe91c3f51c820bf236c091908007209a3583b174cdR901-R903))

### Improvements to `Node` logging:

* Replaced checks for `bindAddr.Empty()` with `bindAddr.EmptyNoPort()` and updated log messages to clarify when both the IP address and port are empty. (`pkg/node/node.go`, [[1]](diffhunk://#diff-515b2d0691202c4ea5e578ec896258ae9c440c381b608ed1eb7116a27847057dL56-R57) [[2]](diffhunk://#diff-515b2d0691202c4ea5e578ec896258ae9c440c381b608ed1eb7116a27847057dL96-R102)

### Unit tests for `TCPAddr`:

* Added unit tests for both `Empty` and `EmptyNoPort` methods in `TCPAddr` to validate their behavior under various scenarios, such as missing ports, unspecified IPs, and invalid addresses. (`pkg/proto/proto_test.go`, [pkg/proto/proto_test.go:R745-R785](diffhunk://#diff-83b634af2d32736559239fb2491f4bb9ebee7ddb67bd0a122d307fd95b45861cR745-R785))