### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/wmd/internal/importer.go
+++ b/cmd/wmd/internal/importer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -268,10 +269,5 @@ func (im *Importer) extractTransactions(transactions []proto.Transaction, miner 
 }
 
 func (im *Importer) checkMatchers(pk crypto.PublicKey) bool {
-	for _, m := range im.matchers {
-		if m == pk {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(im.matchers, pk)
 }

--- a/cmd/wmd/internal/synchronizer.go
+++ b/cmd/wmd/internal/synchronizer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"slices"
 	"strings"
 	"time"
 
@@ -447,10 +448,5 @@ func (s *Synchronizer) extractTransactions(txs []proto.Transaction, miner crypto
 }
 
 func (s *Synchronizer) checkMatcher(pk crypto.PublicKey) bool {
-	for _, m := range s.matchers {
-		if m == pk {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.matchers, pk)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.