### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/pkg/proto/addresses.go
+++ b/pkg/proto/addresses.go
@@ -154,7 +154,7 @@ func (ea EthereumAddress) ToWavesAddress(scheme Scheme) (WavesAddress, error) {
 
 func (ea EthereumAddress) MarshalJSON() ([]byte, error) {
 	hexString := ea.Hex()
-	return []byte(fmt.Sprintf("\"%s\"", hexString)), nil
+	return fmt.Appendf(nil, "\"%s\"", hexString), nil
 }
 
 func (ea *EthereumAddress) UnmarshalJSON(bytes []byte) error {

--- a/pkg/proto/eth_math.go
+++ b/pkg/proto/eth_math.go
@@ -68,7 +68,7 @@ func (i *hexOrDecimal256) MarshalText() ([]byte, error) {
 	if i == nil {
 		return []byte("0x0"), nil
 	}
-	return []byte(fmt.Sprintf("%#x", (*big.Int)(i))), nil
+	return fmt.Appendf(nil, "%#x", (*big.Int)(i)), nil
 }
 
 // paddedEthereumBigIntToBytes encodes a big integer as a big-endian byte slice. The length

--- a/pkg/proto/ethabi/function_signature.go
+++ b/pkg/proto/ethabi/function_signature.go
@@ -125,7 +125,7 @@ func (itb intTextBuilder) MarshalText() (text []byte, err error) {
 	if itb.unsigned {
 		unsignedPrefix = "u"
 	}
-	return []byte(fmt.Sprintf("%sint%d", unsignedPrefix, itb.size)), nil
+	return fmt.Appendf(nil, "%sint%d", unsignedPrefix, itb.size), nil
 }
 
 type fixedBytesTextBuilder struct {
@@ -136,7 +136,7 @@ func (fbtb fixedBytesTextBuilder) MarshalText() (text []byte, err error) {
 	if fbtb.size < 1 || fbtb.size > abiSlotSize {
 		return nil, errors.Errorf("invalid fixed bytes type size (%d)", fbtb.size)
 	}
-	return []byte(fmt.Sprintf("bytes%d", fbtb.size)), nil
+	return fmt.Appendf(nil, "bytes%d", fbtb.size), nil
 }
 
 type bytesTextBuilder struct{}
@@ -166,7 +166,7 @@ func (stb sliceTextBuilder) MarshalText() (text []byte, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal %T", stb.inner)
 	}
-	return []byte(fmt.Sprintf("%s[]", marshaled)), nil
+	return fmt.Appendf(nil, "%s[]", marshaled), nil
 }
 
 type tupleTextBuilder []encoding.TextMarshaler
@@ -180,7 +180,7 @@ func (ttb tupleTextBuilder) MarshalText() (text []byte, err error) {
 		}
 		elements = append(elements, string(marshaled))
 	}
-	return []byte(fmt.Sprintf("(%s)", strings.Join(elements, ","))), nil
+	return fmt.Appendf(nil, "(%s)", strings.Join(elements, ",")), nil
 }
 
 type paymentTextBuilder struct{}
@@ -233,5 +233,5 @@ func (ftb functionTextBuilder) MarshalText() (text []byte, err error) {
 		}
 		elements = append(elements, string(payments))
 	}
-	return []byte(fmt.Sprintf("%s(%s)", ftb.functionMeta.Name, strings.Join(elements, ","))), nil
+	return fmt.Appendf(nil, "%s(%s)", ftb.functionMeta.Name, strings.Join(elements, ",")), nil
 }

--- a/pkg/proto/types.go
+++ b/pkg/proto/types.go
@@ -616,7 +616,7 @@ func (m OrderPriceMode) MarshalJSON() ([]byte, error) {
 	case OrderPriceModeDefault:
 		return []byte(jsonNull), nil
 	default:
-		return []byte(fmt.Sprintf("\"%s\"", m.String())), nil
+		return fmt.Appendf(nil, "\"%s\"", m.String()), nil
 	}
 }
 

--- a/pkg/util/common/util.go
+++ b/pkg/util/common/util.go
@@ -113,7 +113,7 @@ func FromBase58JSON(value []byte, size int, name string) ([]byte, error) {
 }
 
 func ToHexJSON(b []byte) []byte {
-	return []byte(fmt.Sprintf("\"0x%x\"", b))
+	return fmt.Appendf(nil, "\"0x%x\"", b)
 }
 
 func FromHexJSONUnchecked(value []byte, name string) ([]byte, error) {


### PR DESCRIPTION
Optimize code using a more modern writing style. Official support by Go Team. https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

