### PR TITLE
UTX clean-up reimplemented with in-place transactions validation.

### DIFF
--- a/pkg/api/pool.go
+++ b/pkg/api/pool.go
@@ -1,5 +1,5 @@
 package api
 
 func (a *App) PoolTransactions() int {
-	return a.utx.Count()
+	return a.utx.Len()
 }

--- a/pkg/grpc/server/transactions_api.go
+++ b/pkg/grpc/server/transactions_api.go
@@ -210,10 +210,10 @@ func (s *Server) GetUnconfirmed(req *g.TransactionsRequest, srv g.TransactionsAp
 	handler := &getUnconfirmedHandler{srv, s}
 	txs := s.utx.AllTransactions()
 	for _, tx := range txs {
-		if !filter.filter(tx.T) {
+		if !filter.filter(tx) {
 			continue
 		}
-		if hErr := handler.handle(tx.T, proto.TransactionSucceeded); hErr != nil {
+		if hErr := handler.handle(tx, proto.TransactionSucceeded); hErr != nil {
 			return status.Error(codes.Internal, hErr.Error())
 		}
 	}

--- a/pkg/miner/utxpool/pool_test.go
+++ b/pkg/miner/utxpool/pool_test.go
@@ -121,10 +121,10 @@ func TestTransactionPool(t *testing.T) {
 
 	require.EqualValues(t, 0, a.CurSize())
 	// add unique by id transactions, then check them sorted
-	_ = a.AddWithBytes(noState, id([]byte{}, 4), []byte{1})
-	_ = a.AddWithBytes(noState, id([]byte{1}, 1), []byte{1})
-	_ = a.AddWithBytes(noState, id([]byte{1, 2}, 10), []byte{1})
-	_ = a.AddWithBytes(noState, id([]byte{1, 2, 3}, 8), []byte{1})
+	_ = a.AddWithBytes(noState, id(bytes.Repeat([]byte{1}, 32), 4), []byte{1})
+	_ = a.AddWithBytes(noState, id(bytes.Repeat([]byte{2}, 32), 1), []byte{1})
+	_ = a.AddWithBytes(noState, id(bytes.Repeat([]byte{3}, 32), 10), []byte{1})
+	_ = a.AddWithBytes(noState, id(bytes.Repeat([]byte{4}, 32), 8), []byte{1})
 
 	require.EqualValues(t, 10, a.Pop().T.GetFee())
 	require.EqualValues(t, 8, a.Pop().T.GetFee())
@@ -140,13 +140,14 @@ func TestTransactionPool_Exists(t *testing.T) {
 
 	a := New(10000, NoOpValidator{}, settings.MustMainNetSettings())
 
-	require.False(t, a.Exists(id([]byte{1, 2, 3}, 0)))
+	txID := bytes.Repeat([]byte{1}, 32)
+	require.False(t, a.Exists(id(txID, 0)))
 
-	_ = a.AddWithBytes(noState, id([]byte{1, 2, 3}, 10), []byte{1})
-	require.True(t, a.Exists(id([]byte{1, 2, 3}, 0)))
+	_ = a.AddWithBytes(noState, id(txID, 10), []byte{1})
+	require.True(t, a.Exists(id(txID, 0)))
 
 	a.Pop()
-	require.False(t, a.Exists(id([]byte{1, 2, 3}, 0)))
+	require.False(t, a.Exists(id(txID, 0)))
 }
 
 // check transaction not added when limit
@@ -156,13 +157,16 @@ func TestUtxPool_Limit(t *testing.T) {
 	a := New(10, NoOpValidator{}, settings.MustMainNetSettings())
 	require.Equal(t, 0, a.Len())
 
+	txID1 := bytes.Repeat([]byte{1}, 32)
+	txID2 := bytes.Repeat([]byte{2}, 32)
+
 	// added
-	added := a.AddWithBytes(noState, id([]byte{1, 2, 3}, 10), bytes.Repeat([]byte{1, 2}, 5))
+	added := a.AddWithBytes(noState, id(txID1, 10), bytes.Repeat([]byte{1, 2}, 5))
 	require.Equal(t, 1, a.Len())
 	require.NoError(t, added)
 
-	// not added
-	added = a.AddWithBytes(noState, id([]byte{1, 2, 3, 4}, 10), bytes.Repeat([]byte{1, 2}, 5))
+	// not added because of pool size limit
+	added = a.AddWithBytes(noState, id(txID2, 10), bytes.Repeat([]byte{1, 2}, 5))
 	require.Equal(t, 1, a.Len())
 	require.Error(t, added)
 }

--- a/pkg/miner/utxpool/transaction_bulk_validator.go
+++ b/pkg/miner/utxpool/transaction_bulk_validator.go
@@ -32,82 +32,24 @@ func newBulkValidator(state stateWrapper, utx types.UtxPool, tm types.Time, sche
 }
 
 func (a bulkValidator) Validate(ctx context.Context) {
-	transactions := a.validate(ctx) // Pop transactions from UTX, clean UTX
-	for _, t := range transactions {
-		errAdd := a.utx.AddWithBytesRaw(t.T, t.B)
-		if errAdd != nil {
-			// can happen because other nodes can send copies of txs while they are being validated
-			slog.Warn("Failed to add a validated transaction to UTX",
-				logging.Error(errAdd), logging.TxID(t.T, a.scheme),
-			)
-		}
-	}
-}
-
-func (a bulkValidator) validate(ctx context.Context) []*types.TransactionWithBytes {
-	if a.utx.Count() == 0 {
+	if a.utx.Len() == 0 {
 		slog.Debug("UTX pool is empty, nothing to validate")
-		return nil
+		return
 	}
-	var transactions []*types.TransactionWithBytes
 	currentTimestamp := proto.NewTimestampFromTime(a.tm.Now())
 	lastKnownBlock := a.state.TopBlock()
-	dropped := 0
-	for checked := 0; ; checked++ { // just a counter for logging, checking until UTX is empty or context is done
-		if ctx.Err() != nil {
-			slog.Debug("Bulk validation interrupted", logging.Error(context.Cause(ctx)),
-				slog.Int("valid", len(transactions)),
-				slog.Int("checked", checked),
-				slog.Int("dropped", dropped),
-			)
-			return transactions
-		}
-		t := a.utx.Pop()
-		if t == nil {
-			slog.Debug("UTX pool is empty, finished validating",
-				slog.Int("valid", len(transactions)),
-				slog.Int("checked", checked),
-				slog.Int("dropped", dropped),
-			)
-			break
-		}
+	checked, dropped := a.utx.Clean(ctx, func(tx proto.Transaction) bool {
 		err := a.state.TxValidation(func(validation state.TxValidation) error {
-			_, err := validation.ValidateNextTx(t.T, currentTimestamp, lastKnownBlock.Timestamp, lastKnownBlock.Version, false)
+			_, err := validation.ValidateNextTx(tx, currentTimestamp, lastKnownBlock.Timestamp, lastKnownBlock.Version, false)
 			return err
 		})
-		switch {
-		case stateerr.IsTxCommitmentError(err):
-			slog.Error("Failed to unpack a transaction from UTX",
-				logging.Error(err), logging.TxID(t.T, a.scheme),
-				slog.Int("valid", len(transactions)),
-				slog.Int("checked", checked),
-				slog.Int("dropped", dropped),
-			)
-			dropped++ // drop this tx
-			// This should not happen in practice.
-			// Reset state, return applied transactions to UTX.
-			for _, tx := range transactions {
-				utxErr := a.utx.AddWithBytesRaw(tx.T, tx.B)
-				if utxErr != nil {
-					dropped++ // drop this tx
-					slog.Error("Failed to return a transaction to UTX",
-						logging.Error(utxErr), logging.TxID(t.T, a.scheme),
-					)
-				}
+		if err != nil {
+			if stateerr.IsTxCommitmentError(err) {
+				slog.Error("Failed to validate transaction from UTX", logging.Error(err), logging.TxID(tx, a.scheme))
 			}
-			slog.Debug("Valid transactions returned to UTX, resetting list and continuing",
-				slog.Int("returned", len(transactions)),
-				slog.Int("checked", checked),
-				slog.Int("dropped", dropped),
-			)
-			clear(transactions)             // Clear the slice to avoid memory leak
-			transactions = transactions[:0] // Reset the slice to empty
-			continue
-		case err != nil: // invalid tx, just drop it
-			dropped++
-		default: // valid tx
-			transactions = append(transactions, t)
+			return true // Drop invalid transaction.
 		}
-	}
-	return transactions
+		return false // Valid transaction - keep it in UTX.
+	})
+	slog.Debug("Finished UTX pool validation", slog.Int("checked", checked), slog.Int("dropped", dropped))
 }

--- a/pkg/node/fsm/fsm.go
+++ b/pkg/node/fsm/fsm.go
@@ -124,7 +124,7 @@ func (a *BaseInfo) CleanUtx() {
 			a.logger.Debug("CleanUtx completed successfully")
 		}()
 		utxpool.NewCleaner(a.storage, a.utx, a.tm, a.scheme).Clean(ctx)
-		metrics.Utx(a.utx.Count())
+		metrics.Utx(a.utx.Len())
 	}()
 }
 
@@ -160,7 +160,7 @@ func (a *BaseInfo) AddToUtx(t proto.Transaction) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to add transaction to utx")
 	}
-	metrics.Utx(utx.Count())
+	metrics.Utx(utx.Len())
 	return nil
 }
 

--- a/pkg/node/fsm/ng_state.go
+++ b/pkg/node/fsm/ng_state.go
@@ -235,7 +235,7 @@ func (a *NGState) MinedBlock(
 		return a, nil, a.Errorf(err)
 	}
 	metrics.BlockApplied(block, height+1)
-	metrics.Utx(a.baseInfo.utx.Count())
+	metrics.Utx(a.baseInfo.utx.Len())
 	slog.Info("Generated key block successfully applied to state", "state", a.String(),
 		"blockID", block.ID.String())
 

--- a/pkg/node/fsm/wait_snapshot_state.go
+++ b/pkg/node/fsm/wait_snapshot_state.go
@@ -123,7 +123,7 @@ func (a *WaitSnapshotState) BlockSnapshot(
 		return processScoreAfterApplyingOrReturnToNG(a, a.baseInfo, a.receivedScores, a.blocksCache)
 	}
 	metrics.SnapshotBlockApplied(a.blockWaitingForSnapshot, height+1)
-	metrics.Utx(a.baseInfo.utx.Count())
+	metrics.Utx(a.baseInfo.utx.Len())
 	a.baseInfo.logger.Debug("Handle received key block message: block applied to state",
 		"state", a.String(), "blockID", blockID)
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -252,7 +252,7 @@ func (a *Node) runInternalMetrics(
 			l := protoMessagesChan.Len()
 			metrics.FSMChannelLength(l)
 			metricInternalChannelSize.Set(float64(l))
-			metrics.Utx(utx.Count())
+			metrics.Utx(utx.Len())
 		}
 	}
 }

--- a/pkg/state/appender.go
+++ b/pkg/state/appender.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ccoveille/go-safecast"
 	"github.com/mr-tron/base58/base58"
 	"github.com/pkg/errors"
+
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/errs"
 	"github.com/wavesplatform/gowaves/pkg/logging"
@@ -615,7 +616,7 @@ func (a *txAppender) appendTx(tx proto.Transaction, params *appendTxParams) (txS
 	snapshot, err := a.commitTxApplication(tx, params, invocationResult, applicationRes)
 	if err != nil {
 		slog.Error("Failed to commit transaction after successful validation; this should NEVER happen",
-			"ID", base58.Encode(txID))
+			logging.TxID(tx, a.settings.AddressSchemeCharacter), logging.Error(err))
 		return txSnapshot{}, err
 	}
 	// Store additional data for API: transaction by address.

--- a/pkg/state/stateerr/errors.go
+++ b/pkg/state/stateerr/errors.go
@@ -54,8 +54,6 @@ func (err StateError) Unwrap() error {
 func IsTxCommitmentError(err error) bool {
 	var stateErr StateError
 	switch {
-	case err == nil:
-		return false
 	case errors.As(err, &stateErr):
 		return stateErr.Type() == TxCommitmentError
 	default:

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,9 +42,10 @@ type UtxPool interface {
 	AddWithBytesRaw(t proto.Transaction, b []byte) error
 	Exists(t proto.Transaction) bool
 	Pop() *TransactionWithBytes
-	AllTransactions() []*TransactionWithBytes
-	Count() int
+	AllTransactions() []proto.Transaction
+	Len() int
 	ExistsByID(id []byte) bool
+	Clean(ctx context.Context, shouldDrop func(tx proto.Transaction) bool) (int, int)
 }
 
 type TransactionWithBytes struct {


### PR DESCRIPTION
Pool item type heapItem added to store index of item in the heap. Item index management implemented in heap.Interface implementation. AllTransactions function now return slice of proto.Transaction. Function Clean added to UtxPool interface and implemented. Interface function Count renamed to Len, duplicated method removed from implementation.