### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/itests/config/config.go
+++ b/itests/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/pkg/errors"
@@ -111,9 +112,9 @@ func (c *ScalaConfigurator) WithGoNode(goNodeIP string) *ScalaConfigurator {
 }
 
 func (c *ScalaConfigurator) DockerRunOptions() *dockertest.RunOptions {
-	kps := ""
+	var kps strings.Builder
 	for i, kp := range c.knownPeers {
-		kps += fmt.Sprintf("-Dwaves.network.known-peers.%d=%s:%s ", i, kp, BindPort)
+		kps.WriteString(fmt.Sprintf("-Dwaves.network.known-peers.%d=%s:%s ", i, kp, BindPort))
 	}
 	opt := &dockertest.RunOptions{
 		Repository: "wavesplatform/wavesnode",
@@ -128,7 +129,7 @@ func (c *ScalaConfigurator) DockerRunOptions() *dockertest.RunOptions {
 			"WAVES_LOG_LEVEL=TRACE",
 			"WAVES_NETWORK=custom",
 			"JAVA_OPTS=" +
-				kps +
+				kps.String() +
 				"-Dwaves.network.declared-address=scala-node:" + BindPort + " " +
 				"-Dwaves.network.port=" + BindPort + " " +
 				"-Dwaves.rest-api.port=" + RESTAPIPort + " " +

--- a/pkg/ride/compiler/ast_parser.go
+++ b/pkg/ride/compiler/ast_parser.go
@@ -1053,28 +1053,28 @@ func (p *astParser) ruleIntegerHandler(node *node32) (ast.Node, s.Type) {
 
 func (p *astParser) ruleStringHandler(node *node32) (ast.Node, s.Type) {
 	curNode := node.up
-	var res string
+	var res strings.Builder
 	for curNode != nil {
 		switch curNode.pegRule {
 		case ruleChar:
-			res += p.nodeValue(curNode)
+			res.WriteString(p.nodeValue(curNode))
 		case ruleEscapedChar:
 			escapedChar := p.nodeValue(curNode)
 			switch escapedChar {
 			case "\\b":
-				res += "\b"
+				res.WriteString("\b")
 			case "\\f":
-				res += "\f"
+				res.WriteString("\f")
 			case "\\n":
-				res += "\n"
+				res.WriteString("\n")
 			case "\\r":
-				res += "\r"
+				res.WriteString("\r")
 			case "\\t":
-				res += "\t"
+				res.WriteString("\t")
 			case "\\\\":
-				res += "\\"
+				res.WriteString("\\")
 			case "\\\"":
-				res += "\""
+				res.WriteString("\"")
 			default:
 				p.addError(curNode.token32,
 					"Unknown escaped symbol: '%s'. The valid are \\b, \\f, \\n, \\r, \\t, \\\\, \\\"", escapedChar)
@@ -1085,12 +1085,12 @@ func (p *astParser) ruleStringHandler(node *node32) (ast.Node, s.Type) {
 			if err != nil {
 				p.addError(curNode.token32, "Unknown UTF-8 symbol '\\u%s'", unicodeChar)
 			} else {
-				res += char
+				res.WriteString(char)
 			}
 		}
 		curNode = curNode.next
 	}
-	return ast.NewStringNode(res), s.StringType
+	return ast.NewStringNode(res.String()), s.StringType
 }
 
 func (p *astParser) ruleByteVectorHandler(node *node32) (ast.Node, s.Type) {
@@ -1397,18 +1397,18 @@ func (p *astParser) ruleParExprHandler(node *node32) (ast.Node, s.Type) {
 }
 
 func listArgsToString(l []s.Type) string {
-	res := ""
+	var res strings.Builder
 	for i, t := range l {
 		if t == nil {
-			res += "Unknown"
+			res.WriteString("Unknown")
 		} else {
-			res += t.String()
+			res.WriteString(t.String())
 		}
 		if i < len(l)-1 {
-			res += ", "
+			res.WriteString(", ")
 		}
 	}
-	return res
+	return res.String()
 }
 
 func (p *astParser) ruleFunctionCallHandler(node *node32, firstArg ast.Node, firstArgType s.Type) (ast.Node, s.Type) {

--- a/pkg/ride/compiler/stdlib/types.go
+++ b/pkg/ride/compiler/stdlib/types.go
@@ -468,20 +468,20 @@ func (t TupleType) EqualWithEntry(other Type) bool {
 }
 
 func (t TupleType) String() string {
-	var res string
-	res += "("
+	var res strings.Builder
+	res.WriteString("(")
 	for i, k := range t.Types {
 		if k == nil {
-			res += "nil"
+			res.WriteString("nil")
 		} else {
-			res += k.String()
+			res.WriteString(k.String())
 		}
 		if i < len(t.Types)-1 {
-			res += ", "
+			res.WriteString(", ")
 		}
 	}
-	res += ")"
-	return res
+	res.WriteString(")")
+	return res.String()
 }
 
 func loadNonConfigTypes(res map[ast.LibraryVersion]map[string]Type) {


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)  

Inspired by https://github.com/helm/helm/pull/31292/files