### PR TITLE
Fix : typos in docs

### DIFF
--- a/cmd/wmd/README.md
+++ b/cmd/wmd/README.md
@@ -35,7 +35,7 @@ usage: wmd [flags]
   -matcher          Matcher's public key in form of Base58 string. Defaults to 7kPFrHDiGw1rCm7LPszuECwWYL3dMf6iMifLRDJQZMzy.
   -scheme           Blockchain scheme symbol. Defaults to 'W'.
   -symbols          Path to file of symbol substitutions. No default value.
-  -rollback         The height to rollback to before importing a blockchain file or staring the synchronization. Default value is 0 (no rollback).
+  -rollback         The height to rollback to before importing a blockchain file or starting the synchronization. Default value is 0 (no rollback).
 
 ```
 

--- a/pkg/state/docs/design.md
+++ b/pkg/state/docs/design.md
@@ -2,7 +2,7 @@
 
 #### Storage
 
-Blocks have unique numbers (not heights!). When state accepts new block, it assigns
+Blocks have unique numbers (not heights!). When state accepts a new block, it assigns
 unique number for this block ID. Block nums start from zero and increase.
 These numbers are used in storage instead of long block IDs.
 


### PR DESCRIPTION
Typo fixes
Caught a couple typos while reading through:
Fixed "staring" → "starting" in README (we're starting sync, not staring at it )
Fixed "accepts new" → "accepts a new" in design doc (grammar)