### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/pkg/crypto/merkle.go
+++ b/pkg/crypto/merkle.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"hash"
+	"slices"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
@@ -66,11 +67,11 @@ func (t *MerkleTree) Root() Digest {
 
 func (t *MerkleTree) RebuildRoot(leaf Digest, proofsRootToLeafsOrder []Digest, index uint64) Digest {
 	digest := leaf
-	for i := len(proofsRootToLeafsOrder) - 1; i >= 0; i-- { // Iterate from leafs to root, i.e. in reverse order
+	for _, v := range slices.Backward(proofsRootToLeafsOrder) { // Iterate from leafs to root, i.e. in reverse order
 		if index%2 == 0 { // Left
-			digest = t.nodeDigest(digest, proofsRootToLeafsOrder[i])
+			digest = t.nodeDigest(digest, v)
 		} else { // Right
-			digest = t.nodeDigest(proofsRootToLeafsOrder[i], digest)
+			digest = t.nodeDigest(v, digest)
 		}
 		index = index / 2
 	}

--- a/pkg/ride/compiler.go
+++ b/pkg/ride/compiler.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
+	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
@@ -417,9 +418,9 @@ func (c *compiler) peekValue() error {
 }
 
 func (c *compiler) lookupValue(name string) (rideValue, error) {
-	for i := len(c.values) - 1; i >= 0; i-- {
-		if c.values[i].id() == name {
-			return c.values[i], nil
+	for _, v := range slices.Backward(c.values) {
+		if v.id() == name {
+			return v, nil
 		}
 	}
 	return nil, errors.Errorf("value '%s' is not declared", name)
@@ -467,9 +468,9 @@ func (c *compiler) peekFunction() error {
 }
 
 func (c *compiler) lookupFunction(name string) (*localFunction, error) {
-	for i := len(c.functions) - 1; i >= 0; i-- {
-		if c.functions[i].name == name {
-			return c.functions[i], nil
+	for _, v := range slices.Backward(c.functions) {
+		if v.name == name {
+			return v, nil
 		}
 	}
 	return nil, errors.Errorf("function '%s' is not declared", name)

--- a/pkg/ride/compiler/ast_parser.go
+++ b/pkg/ride/compiler/ast_parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1957,8 +1958,8 @@ func (p *astParser) ruleMatchHandler(node *node32) (ast.Node, s.Type) {
 		defaultCase = ast.NewFunctionCallNode(ast.NativeFunction("2"), []ast.Node{ast.NewStringNode("Match error")})
 	}
 	falseState := defaultCase
-	for i := len(conds) - 1; i >= 0; i-- {
-		falseState = ast.NewConditionalNode(conds[i], trueStates[i], falseState)
+	for i, v := range slices.Backward(conds) {
+		falseState = ast.NewConditionalNode(v, trueStates[i], falseState)
 	}
 	p.stack.dropFrame()
 	return ast.NewAssignmentNode(matchName, expr, falseState), unionRetType.Simplify()
@@ -1986,9 +1987,9 @@ func (p *astParser) ruleCaseHandle(node *node32, matchName string, possibleTypes
 		if decls == nil {
 			trueState = block
 		} else {
-			for i := len(decls) - 1; i >= 0; i-- {
-				decls[i].SetBlock(block)
-				block = decls[i]
+			for _, v := range slices.Backward(decls) {
+				v.SetBlock(block)
+				block = v
 			}
 			trueState = block
 		}
@@ -2002,9 +2003,9 @@ func (p *astParser) ruleCaseHandle(node *node32, matchName string, possibleTypes
 		if decls == nil {
 			trueState = block
 		} else {
-			for i := len(decls) - 1; i >= 0; i-- {
-				decls[i].SetBlock(block)
-				block = decls[i]
+			for _, v := range slices.Backward(decls) {
+				v.SetBlock(block)
+				block = v
 			}
 			trueState = block
 		}
@@ -2134,23 +2135,23 @@ func (p *astParser) ruleObjectPatternHandler(node *node32, matchName string, pos
 
 	var resExpr ast.Node
 
-	for i := len(exprs) - 1; i >= 0; i-- {
-		if exprs[i] == nil {
+	for i, v := range slices.Backward(exprs) {
+		if v == nil {
 			continue
 		}
 		if i == len(exprs)-1 && i != 0 {
-			resExpr = exprs[i]
+			resExpr = v
 			continue
 		}
 		if i == 0 {
-			resExpr = ast.NewConditionalNode(exprs[i], ast.NewAssignmentNode(
+			resExpr = ast.NewConditionalNode(v, ast.NewAssignmentNode(
 				matchName,
 				ast.NewReferenceNode(matchName),
 				resExpr,
 			), ast.NewBooleanNode(false))
 			continue
 		}
-		resExpr = ast.NewConditionalNode(exprs[i], resExpr, ast.NewBooleanNode(false))
+		resExpr = ast.NewConditionalNode(v, resExpr, ast.NewBooleanNode(false))
 	}
 
 	return resExpr, shadowDeclarations
@@ -2255,17 +2256,17 @@ func (p *astParser) ruleTuplePatternHandler(node *node32, matchName string, poss
 	var cond ast.Node
 	setLast := false
 	setPlaceHolder := false
-	for i := len(exprs) - 1; i >= 0; i-- {
-		if exprs[i] == nil {
+	for _, v := range slices.Backward(exprs) {
+		if v == nil {
 			setPlaceHolder = true
 			continue
 		}
 		if !setLast {
-			cond = exprs[i]
+			cond = v
 			setLast = true
 			continue
 		}
-		cond = ast.NewConditionalNode(exprs[i], cond, ast.NewBooleanNode(false))
+		cond = ast.NewConditionalNode(v, cond, ast.NewBooleanNode(false))
 	}
 	if cond == nil {
 		cond = ast.NewBooleanNode(true)
@@ -2417,8 +2418,8 @@ func (p *astParser) ruleFoldMacroHandler(node *node32) (ast.Node, s.Type) {
 	decls = append(decls, fcall)
 
 	var expr, block ast.Node
-	for i := len(decls) - 1; i >= 0; i-- {
-		expr = decls[i]
+	for _, v := range slices.Backward(decls) {
+		expr = v
 		expr.SetBlock(block)
 		block = expr
 	}

--- a/pkg/ride/compiler/stack.go
+++ b/pkg/ride/compiler/stack.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/compiler/stdlib"
@@ -50,27 +51,27 @@ func (s *stack) pushFunc(f stdlib.FunctionParams) {
 }
 
 func (s *stack) variable(name string) (stdlib.Variable, bool) {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		if name == s.vars[i].Name {
-			return s.vars[i], true
+	for _, v := range slices.Backward(s.vars) {
+		if name == v.Name {
+			return v, true
 		}
 	}
 	return stdlib.Variable{}, false
 }
 
 func (s *stack) topMatchName() (string, bool) {
-	for i := len(s.vars) - 1; i >= 0; i-- {
-		if strings.HasPrefix(s.vars[i].Name, "$match") {
-			return s.vars[i].Name, true
+	for _, v := range slices.Backward(s.vars) {
+		if strings.HasPrefix(v.Name, "$match") {
+			return v.Name, true
 		}
 	}
 	return "", false
 }
 
 func (s *stack) function(name string) (stdlib.FunctionParams, bool) {
-	for i := len(s.funcs) - 1; i >= 0; i-- {
-		if name == s.funcs[i].ID.Name() {
-			return s.funcs[i], true
+	for _, v := range slices.Backward(s.funcs) {
+		if name == v.ID.Name() {
+			return v, true
 		}
 	}
 	return stdlib.FunctionParams{}, false

--- a/pkg/ride/errors.go
+++ b/pkg/ride/errors.go
@@ -2,6 +2,7 @@ package ride
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/pkg/errors"
 )
@@ -52,8 +53,8 @@ func (e *implEvaluationError) ErrorType() EvaluationError { return e.errorType }
 
 func (e *implEvaluationError) CallStack() []string {
 	callStack := make([]string, 0, len(e.reverseCallStack))
-	for i := len(e.reverseCallStack) - 1; i >= 0; i-- {
-		callStack = append(callStack, e.reverseCallStack[i])
+	for _, v := range slices.Backward(e.reverseCallStack) {
+		callStack = append(callStack, v)
 	}
 	return callStack
 }

--- a/pkg/ride/functions_list.go
+++ b/pkg/ride/functions_list.go
@@ -372,8 +372,8 @@ func lastIndexOfList(_ environment, args ...rideType) (rideType, error) {
 	if len(list) > maxListSize {
 		return nil, errors.Errorf("lastIndexOfList: list size exceeds %d elements", maxListSize)
 	}
-	for i := len(list) - 1; i >= 0; i-- {
-		if e.eq(list[i]) {
+	for i, v := range slices.Backward(list) {
+		if e.eq(v) {
 			return rideInt(i), nil
 		}
 	}

--- a/pkg/ride/functions_proto.go
+++ b/pkg/ride/functions_proto.go
@@ -1196,8 +1196,8 @@ func rebuildMerkleRoot(_ environment, args ...rideType) (rideType, error) {
 		return nil, errors.New("rebuildMerkleRoot: no more than 16 proofs is allowed")
 	}
 	proofsRootToLeafsOrder := make([]crypto.Digest, 0, len(proofsLeafsToRootOrder))
-	for i := len(proofsLeafsToRootOrder) - 1; i >= 0; i-- { // reverse order
-		x := proofsLeafsToRootOrder[i]
+	for i, v := range slices.Backward(proofsLeafsToRootOrder) { // reverse order
+		x := v
 		b, ok := x.(rideByteVector)
 		if !ok {
 			return nil, errors.Errorf("rebuildMerkleRoot: unexpected proof type '%s' at position %d", x.instanceOf(), i)

--- a/pkg/ride/tree_estimatorV1.go
+++ b/pkg/ride/tree_estimatorV1.go
@@ -1,6 +1,8 @@
 package ride
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
@@ -34,9 +36,9 @@ func (s *estimationScopeV1) setValue(id string, n ast.Node) {
 }
 
 func (s *estimationScopeV1) value(id string) (ast.Node, error) {
-	for i := len(s.values) - 1; i >= 0; i-- {
-		if s.values[i].id == id {
-			return s.values[i].n, nil
+	for _, v := range slices.Backward(s.values) {
+		if v.id == id {
+			return v.n, nil
 		}
 	}
 	return nil, errors.Errorf("value '%s' not found", id)
@@ -164,9 +166,9 @@ func (e *treeEstimatorV1) wrapFunction(node *ast.FunctionDeclarationNode) ast.No
 	node.SetBlock(ast.NewFunctionCallNode(ast.UserFunction(node.Name), args))
 	var block ast.Node
 	block = ast.NewAssignmentNode(node.InvocationParameter, ast.NewBooleanNode(true), node)
-	for i := len(e.tree.Declarations) - 1; i >= 0; i-- {
-		e.tree.Declarations[i].SetBlock(block)
-		block = e.tree.Declarations[i]
+	for _, v := range slices.Backward(e.tree.Declarations) {
+		v.SetBlock(block)
+		block = v
 	}
 	return block
 }

--- a/pkg/ride/tree_estimatorV2.go
+++ b/pkg/ride/tree_estimatorV2.go
@@ -1,6 +1,8 @@
 package ride
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
@@ -31,9 +33,9 @@ func (s *estimationScopeV2) setValue(id string, n ast.Node) {
 }
 
 func (s *estimationScopeV2) value(id string) (ast.Node, error) {
-	for i := len(s.values) - 1; i >= 0; i-- {
-		if s.values[i].id == id {
-			return s.values[i].n, nil
+	for _, v := range slices.Backward(s.values) {
+		if v.id == id {
+			return v.n, nil
 		}
 	}
 	return nil, errors.Errorf("value '%s' not found", id)
@@ -52,9 +54,9 @@ func (s *estimationScopeV2) setFunction(n *ast.FunctionDeclarationNode) {
 }
 
 func (s *estimationScopeV2) function(id string) (*ast.FunctionDeclarationNode, error) {
-	for i := len(s.functions) - 1; i >= 0; i-- {
-		if s.functions[i].Name == id {
-			return s.functions[i], nil
+	for _, v := range slices.Backward(s.functions) {
+		if v.Name == id {
+			return v, nil
 		}
 	}
 	return nil, errors.Errorf("function '%s' not found", id)
@@ -168,9 +170,9 @@ func (e *treeEstimatorV2) wrapFunction(node *ast.FunctionDeclarationNode) ast.No
 	node.SetBlock(ast.NewFunctionCallNode(ast.UserFunction(node.Name), args))
 	var block ast.Node
 	block = ast.NewAssignmentNode(node.InvocationParameter, ast.NewBooleanNode(true), node)
-	for i := len(e.tree.Declarations) - 1; i >= 0; i-- {
-		e.tree.Declarations[i].SetBlock(block)
-		block = e.tree.Declarations[i]
+	for _, v := range slices.Backward(e.tree.Declarations) {
+		v.SetBlock(block)
+		block = v
 	}
 	return block
 }

--- a/pkg/ride/tree_estimatorV3.go
+++ b/pkg/ride/tree_estimatorV3.go
@@ -1,6 +1,8 @@
 package ride
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
@@ -102,8 +104,8 @@ func (s *estimationScopeV3) function(function ast.Function) (functionDescriptor,
 
 func (s *estimationScopeV3) used(id string) bool {
 	if l := len(s.usages); l > 0 {
-		for i := len(s.usages[l-1]) - 1; i >= 0; i-- {
-			if s.usages[l-1][i] == id {
+		for _, v := range slices.Backward(s.usages[l-1]) {
+			if v == id {
 				return true
 			}
 		}
@@ -113,8 +115,8 @@ func (s *estimationScopeV3) used(id string) bool {
 
 func (s *estimationScopeV3) remove(id string) {
 	if l := len(s.usages); l > 0 {
-		for i := len(s.usages[l-1]) - 1; i >= 0; i-- {
-			if s.usages[l-1][i] == id {
+		for i, v := range slices.Backward(s.usages[l-1]) {
+			if v == id {
 				s.usages[l-1] = append(s.usages[l-1][:i], s.usages[l-1][i+1:]...)
 			}
 		}
@@ -231,9 +233,9 @@ func (e *treeEstimatorV3) wrapFunction(node *ast.FunctionDeclarationNode) ast.No
 	node.SetBlock(ast.NewFunctionCallNode(ast.UserFunction(node.Name), args))
 	var block ast.Node
 	block = ast.NewAssignmentNode(node.InvocationParameter, ast.NewBooleanNode(true), node)
-	for i := len(e.tree.Declarations) - 1; i >= 0; i-- {
-		e.tree.Declarations[i].SetBlock(block)
-		block = e.tree.Declarations[i]
+	for _, v := range slices.Backward(e.tree.Declarations) {
+		v.SetBlock(block)
+		block = v
 	}
 	return block
 }

--- a/pkg/ride/tree_estimatorV4.go
+++ b/pkg/ride/tree_estimatorV4.go
@@ -1,6 +1,8 @@
 package ride
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/wavesplatform/gowaves/pkg/ride/ast"
@@ -100,9 +102,9 @@ func (e *treeEstimatorV4) wrapFunction(node *ast.FunctionDeclarationNode) ast.No
 	node.SetBlock(ast.NewFunctionCallNode(ast.UserFunction(node.Name), args))
 	var block ast.Node
 	block = ast.NewAssignmentNode(node.InvocationParameter, ast.NewBooleanNode(true), node)
-	for i := len(e.tree.Declarations) - 1; i >= 0; i-- {
-		e.tree.Declarations[i].SetBlock(block)
-		block = e.tree.Declarations[i]
+	for _, v := range slices.Backward(e.tree.Declarations) {
+		v.SetBlock(block)
+		block = v
 	}
 	return block
 }

--- a/pkg/ride/tree_evaluator.go
+++ b/pkg/ride/tree_evaluator.go
@@ -1,6 +1,8 @@
 package ride
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 
 	"github.com/wavesplatform/gowaves/pkg/proto"
@@ -77,8 +79,8 @@ func (s *evaluationScope) constant(id string) (rideType, bool) {
 }
 
 func lookup(s []esValue, id string) (esValue, bool, int) {
-	for i := len(s) - 1; i >= 0; i-- {
-		if v := s[i]; v.id == id {
+	for i, v := range slices.Backward(s) {
+		if v := v; v.id == id {
 			return v, true, i
 		}
 	}
@@ -115,8 +117,8 @@ func (s *evaluationScope) popUserFunction() error {
 }
 
 func (s *evaluationScope) userFunction(id string) (*ast.FunctionDeclarationNode, int, bool) {
-	for i := len(s.user) - 1; i >= 0; i-- {
-		uf := s.user[i]
+	for _, v := range slices.Backward(s.user) {
+		uf := v
 		if uf.fn.Name == id {
 			return uf.fn, uf.sp, true
 		}

--- a/pkg/ride/vm.go
+++ b/pkg/ride/vm.go
@@ -2,6 +2,7 @@ package ride
 
 import (
 	"encoding/binary"
+	"slices"
 
 	"github.com/pkg/errors"
 )
@@ -130,7 +131,7 @@ func (m *vm) run() (Result, error) {
 			m.ip = pos // Continue to expression
 		case OpLoadLocal:
 			n := m.arg16()
-			for i := len(m.calls) - 1; i >= 0; i-- {
+			for i, v := range slices.Backward(m.calls) {
 
 			}
 			l := len(m.calls)

--- a/pkg/state/balances.go
+++ b/pkg/state/balances.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/fxamacker/cbor/v2"
@@ -698,8 +699,8 @@ func isChallengedAddressInRangeCommon(
 		return false, errors.Wrapf(ubErr, "failed to unmarshal entry data to %T", r)
 	}
 	// assume that heights are sorted in ascending order
-	for i := len(r.Heights) - 1; i >= 0; i-- { // iterate in reverse order
-		h := r.Heights[i]
+	for _, v := range slices.Backward(r.Heights) { // iterate in reverse order
+		h := v
 		if h < startHeight { // fast path: if h < startHeight, then all other heights are also less than startHeight
 			return false, nil
 		}

--- a/pkg/state/history_formatter.go
+++ b/pkg/state/history_formatter.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"slices"
+
 	"github.com/pkg/errors"
 )
 
@@ -28,8 +30,8 @@ func (hfmt *historyFormatter) filter(history *historyRecord) (bool, error) {
 		return false, nil
 	}
 	changed := false
-	for i := len(history.entries) - 1; i >= 0; i-- {
-		entry := history.entries[i]
+	for i, v := range slices.Backward(history.entries) {
+		entry := v
 		valid, err := hfmt.db.isValidBlock(entry.blockNum)
 		if err != nil {
 			return false, err

--- a/pkg/state/monetary_policy.go
+++ b/pkg/state/monetary_policy.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/binary"
+	"slices"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/pkg/errors"
@@ -290,8 +291,8 @@ func calculateTotalAmount(
 	curTotalAmount uint64,
 	br *boostedReward,
 ) uint64 {
-	for i := len(changesRecords) - 1; i >= 0; i-- {
-		change := changesRecords[i]
+	for _, v := range slices.Backward(changesRecords) {
+		change := v
 		if relativeHeight < change.Height {
 			continue
 		}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899