### PR TITLE
Update 'workflow_dispatch' inputs for deploy workflow.

### DIFF
--- a/.github/workflows/deploy_node.yml
+++ b/.github/workflows/deploy_node.yml
@@ -4,13 +4,20 @@ on:
     inputs:
       network:
         required: true
-        type: string
+        type: choice
         description: "Waves network name (mainnet, testnet, stagenet)"
+        options:
+          - mainnet
+          - testnet
+          - stagenet
       arch:
         required: true
-        type: string
+        type: choice
         description: "Machine architecture (amd64, arm64)"
         default: "amd64"
+        options:
+          - amd64
+          - arm64
   workflow_call:
     inputs:
       network:

--- a/.github/workflows/deploy_nodes.yml
+++ b/.github/workflows/deploy_nodes.yml
@@ -7,9 +7,12 @@ on:
     inputs:
       arch:
         required: true
-        type: string
+        type: choice
         description: "Machine architecture (amd64, arm64)"
         default: "amd64"
+        options:
+          - amd64
+          - arm64
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request updates the input parameter types in the GitHub Actions workflow configuration files to use the `choice` type instead of `string` for certain inputs. This change enforces stricter input validation and provides selectable options in the workflow UI, reducing the risk of invalid values.

**Workflow input improvements:**

* Changed the `network` input in `.github/workflows/deploy_node.yml` from `string` to `choice` and specified allowed options: `mainnet`, `testnet`, `stagenet`.
* Changed the `arch` input in both `.github/workflows/deploy_node.yml` and `.github/workflows/deploy_nodes.yml` from `string` to `choice` and specified allowed options: `amd64`, `arm64`. [[1]](diffhunk://#diff-2883c238d190b138336f04e76e058f7057ada327c04063fa207f802a1f0e577aL7-R20) [[2]](diffhunk://#diff-dd0e68aaaa7295b6101188d16283e99bf33c9bc2341908700f520f6de7a7643eL10-R15)