### PR TITLE
Implemented 'debug/blacklist' HTTP API method.

### DIFF
--- a/pkg/api/node_api.go
+++ b/pkg/api/node_api.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/pkg/errors"
 
 	"github.com/ccoveille/go-safecast/v2"
@@ -637,6 +638,23 @@ func (a *NodeApi) PeersClearBlackList(w http.ResponseWriter, _ *http.Request) er
 		return errors.Wrap(err, "PeersBlackListed")
 	}
 	return nil
+}
+
+func (a *NodeApi) PeersBlackList(w http.ResponseWriter, r *http.Request) error {
+	defer r.Body.Close() // ensure that body will be closed after reading, even if error occurs
+	bodyBytesRaw, err := io.ReadAll(io.LimitReader(r.Body, postMessageSizeLimit))
+	if err != nil {
+		return apiErrs.NewBadRequestError(
+			errors.Wrap(err, "PeersBlackList: failed to read request body"),
+		)
+	}
+	bodyStr := strings.TrimSpace(string(bodyBytesRaw))
+	requestID := middleware.GetReqID(r.Context())
+	clientIP := middleware.GetClientIP(r.Context())
+	if clientIP == "" {
+		clientIP = r.RemoteAddr
+	}
+	return a.app.PeersBlackList(bodyStr, requestID, clientIP)
 }
 
 func (a *NodeApi) BlocksGenerators(w http.ResponseWriter, _ *http.Request) error {

--- a/pkg/api/node_api.go
+++ b/pkg/api/node_api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	stderrs "errors"
@@ -648,7 +649,10 @@ func (a *NodeApi) PeersBlackList(w http.ResponseWriter, r *http.Request) error {
 			errors.Wrap(err, "PeersBlackList: failed to read request body"),
 		)
 	}
-	bodyStr := strings.TrimSpace(string(bodyBytesRaw))
+	bodyBytes := bytes.TrimSpace(bodyBytesRaw)
+	// remove leading / if present to be compatible with responses like '/ip:port'
+	// (e.g. values copied from peers list responses like "/ip:port")
+	bodyStr := string(bytes.TrimPrefix(bodyBytes, []byte(`/`)))
 	requestID := middleware.GetReqID(r.Context())
 	clientIP := middleware.GetClientIP(r.Context())
 	if clientIP == "" {

--- a/pkg/api/node_api_test.go
+++ b/pkg/api/node_api_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,11 +13,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	apiErrs "github.com/wavesplatform/gowaves/pkg/api/errors"
 	"github.com/wavesplatform/gowaves/pkg/crypto"
 	"github.com/wavesplatform/gowaves/pkg/crypto/bls"
+	"github.com/wavesplatform/gowaves/pkg/node/peers"
 	"github.com/wavesplatform/gowaves/pkg/proto"
 	"github.com/wavesplatform/gowaves/pkg/services"
 	"github.com/wavesplatform/gowaves/pkg/settings"
@@ -252,4 +256,120 @@ func (w *testWallet) AccountSeeds() [][]byte {
 
 func (w *testWallet) BLSSecretKeys() ([]bls.SecretKey, error) {
 	return []bls.SecretKey{w.blsSk}, nil
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("read error")
+}
+
+func TestNodeApi_PeersBlackList(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		peerManager := peers.NewMockPeerManager(t)
+
+		const blacklistedIP = "5.3.6.7"
+		const blacklistedPort = 6868
+		blacklistedAddr := proto.NewTCPAddr(net.ParseIP(blacklistedIP), blacklistedPort)
+
+		peerManager.EXPECT().AddToBlackListByAddr(
+			mock.MatchedBy(func(addr proto.TCPAddr) bool {
+				return addr.String() == blacklistedAddr.String()
+			}),
+			mock.MatchedBy(func(t any) bool { return true }),
+			mock.MatchedBy(func(reason string) bool { return reason != "" }),
+		).Return().Times(1)
+
+		app, err := NewApp("", nil, services.Services{
+			Peers:  peerManager,
+			Scheme: proto.TestNetScheme,
+		}, cfg)
+		require.NoError(t, err)
+
+		api := NewNodeAPI(app, nil)
+
+		// Test with body containing IP:port (no leading slash)
+		bodyStr := fmt.Sprintf("%s:%d", blacklistedIP, blacklistedPort)
+		req := httptest.NewRequest(http.MethodPost, "/peers/blacklist", strings.NewReader(bodyStr))
+		resp := httptest.NewRecorder()
+
+		err = api.PeersBlackList(resp, req)
+		require.NoError(t, err)
+	})
+
+	t.Run("success with leading slash", func(t *testing.T) {
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		peerManager := peers.NewMockPeerManager(t)
+
+		const blacklistedIP = "10.0.0.1"
+		const blacklistedPort = 6868
+		blacklistedAddr := proto.NewTCPAddr(net.ParseIP(blacklistedIP), blacklistedPort)
+
+		// Handler strips leading slash, so the app receives without it
+		peerManager.EXPECT().AddToBlackListByAddr(
+			mock.MatchedBy(func(addr proto.TCPAddr) bool {
+				return addr.String() == blacklistedAddr.String()
+			}),
+			mock.MatchedBy(func(t any) bool { return true }),
+			mock.MatchedBy(func(reason string) bool { return reason != "" }),
+		).Return().Times(1)
+
+		app, err := NewApp("", nil, services.Services{
+			Peers:  peerManager,
+			Scheme: proto.TestNetScheme,
+		}, cfg)
+		require.NoError(t, err)
+
+		api := NewNodeAPI(app, nil)
+
+		// Test with body containing leading slash (format from peer list responses)
+		bodyStr := fmt.Sprintf("/%s:%d", blacklistedIP, blacklistedPort)
+		req := httptest.NewRequest(http.MethodPost, "/peers/blacklist", strings.NewReader(bodyStr))
+		resp := httptest.NewRecorder()
+
+		err = api.PeersBlackList(resp, req)
+		require.NoError(t, err)
+	})
+
+	t.Run("error reading body", func(t *testing.T) {
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		peerManager := peers.NewMockPeerManager(t)
+
+		app, err := NewApp("", nil, services.Services{
+			Peers:  peerManager,
+			Scheme: proto.TestNetScheme,
+		}, cfg)
+		require.NoError(t, err)
+
+		api := NewNodeAPI(app, nil)
+
+		// Create a request and replace the body with a failing reader
+		req := httptest.NewRequest(http.MethodPost, "/peers/blacklist", strings.NewReader("5.3.6.7:6868"))
+
+		// Create a custom body that fails on first read by using LimitedReader
+		// that exhausts immediately and then fails
+		defer req.Body.Close() // close the original body to avoid resource leak
+		req.Body = io.NopCloser(failingReader{})
+		resp := httptest.NewRecorder()
+
+		err = api.PeersBlackList(resp, req)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "failed to read request body"))
+	})
 }

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -159,7 +159,11 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
 	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
 	if tcpAddr.Empty() {
-		slog.Error("Invalid peer's address to blacklist", "address", blacklistedAddr)
+		slog.Error("Invalid peer's address to blacklist",
+			slog.String("address", blacklistedAddr),
+			slog.String("client-ip", clientIP),
+			slog.String("request-id", requestID),
+		)
 		return apiErrs.NewBadRequestError(errors.Errorf("invalid address format: %s", blacklistedAddr))
 	}
 	now := time.Now()

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -155,6 +155,21 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 	return out
 }
 
+func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
+	d := proto.NewTCPAddrFromString(blacklistedAddr)
+	if d.Empty() {
+		slog.Error("Invalid peer's address to blacklist", "address", blacklistedAddr)
+		return apiErrs.NewBadRequestError(errors.Errorf("invalid address format: %s", blacklistedAddr))
+	}
+	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
+	now := time.Now()
+	reason := fmt.Sprintf("blacklisted by API at local now='%v' by client='%s' with request-id='%s'",
+		now, clientIP, requestID,
+	)
+	a.peers.AddToBlackListByAddr(tcpAddr, now, reason)
+	return nil
+}
+
 type PeersClearBlackListResponse struct {
 	Result string `json:"result"`
 }

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -156,12 +156,11 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 }
 
 func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
-	d := proto.NewTCPAddrFromString(blacklistedAddr)
-	if d.Empty() {
+	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
+	if tcpAddr.Empty() {
 		slog.Error("Invalid peer's address to blacklist", "address", blacklistedAddr)
 		return apiErrs.NewBadRequestError(errors.Errorf("invalid address format: %s", blacklistedAddr))
 	}
-	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
 	now := time.Now()
 	reason := fmt.Sprintf("blacklisted by API at local now='%v' by client='%s' with request-id='%s'",
 		now, clientIP, requestID,

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -159,7 +159,7 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
 	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
 	if tcpAddr.Empty() {
-		slog.Error("Invalid peer's address to blacklist",
+		slog.Info("Invalid peer's address to blacklist",
 			slog.String("address", blacklistedAddr),
 			slog.String("client-ip", clientIP),
 			slog.String("request-id", requestID),
@@ -168,8 +168,8 @@ func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error 
 	}
 	now := time.Now().UTC()
 	reason := fmt.Sprintf(
-		"blacklisted by API at %s by client='%s' with request-id='%s' address='%s'",
-		now.Format(time.RFC3339Nano), clientIP, requestID, tcpAddr.String(),
+		"blacklisted by API at now='%s' by client='%s' with request-id='%s' address='%s'",
+		now.Format(time.RFC3339), clientIP, requestID, tcpAddr.String(),
 	)
 	a.peers.AddToBlackListByAddr(tcpAddr, now, reason)
 	return nil

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -38,13 +38,14 @@ func (a *App) PeersAll() (PeersKnown, error) {
 
 	out := make([]Peer, 0, len(knownPeers))
 	for _, knownPeer := range knownPeers {
-		ip := knownPeer.String()
-		if _, in := restrictedIPsMap[ip]; in {
+		ip := knownPeer.IP() // extract IP from KnownPeer
+		ipStr := ip.String() // convert IP to string for comparison
+		if _, in := restrictedIPsMap[ipStr]; in {
 			continue
 		}
 		// FIXME(nickeksov): add normal lastSeen field
 		out = append(out, Peer{
-			Address:  "/" + ip,
+			Address:  "/" + knownPeer.String(), // addr with port
 			LastSeen: uint64(nowMillis),
 		})
 	}

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -166,9 +166,10 @@ func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error 
 		)
 		return apiErrs.NewBadRequestError(errors.Errorf("invalid address format: %s", blacklistedAddr))
 	}
-	now := time.Now()
-	reason := fmt.Sprintf("blacklisted by API at local now='%v' by client='%s' with request-id='%s'",
-		now, clientIP, requestID,
+	now := time.Now().UTC()
+	reason := fmt.Sprintf(
+		"blacklisted by API at %s by client='%s' with request-id='%s' address='%s'",
+		now.Format(time.RFC3339Nano), clientIP, requestID, tcpAddr.String(),
 	)
 	a.peers.AddToBlackListByAddr(tcpAddr, now, reason)
 	return nil

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -75,3 +75,39 @@ func TestApp_PeersBlackListed(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	}
 }
+
+func TestApp_PeersAll(t *testing.T) {
+	peerManager := peers.NewMockPeerManager(t)
+
+	const blackListedIPStr = "13.3.4.1"
+	blackListedIP := storage.IPFromString(blackListedIPStr)
+	peerManager.EXPECT().BlackList().Return([]storage.BlackListedPeer{{
+		IP:                      blackListedIP,
+		RestrictTimestampMillis: time.Now().UnixMilli(),
+		RestrictDuration:        time.Minute,
+		Reason:                  "some reason",
+	}})
+
+	allowedAddr := proto.NewTCPAddr(net.ParseIP("5.3.6.7"), 6868).ToIpPort()
+	blackListedAddr := proto.NewTCPAddr(net.ParseIP(blackListedIPStr), 6868).ToIpPort()
+	peerManager.EXPECT().KnownPeers().Return([]storage.KnownPeer{
+		storage.KnownPeer(allowedAddr),
+		storage.KnownPeer(blackListedAddr),
+	})
+
+	cfg := &settings.BlockchainSettings{
+		FunctionalitySettings: settings.FunctionalitySettings{
+			GenerationPeriod: 0,
+		},
+	}
+
+	app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+	require.NoError(t, err)
+
+	out, err := app.PeersAll()
+	require.NoError(t, err)
+	require.Len(t, out.Peers, 1)
+	addresses := []string{out.Peers[0].Address}
+	assert.ElementsMatch(t, []string{"/5.3.6.7:6868"}, addresses)
+	assert.NotZero(t, out.Peers[0].LastSeen)
+}

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wavesplatform/gowaves/pkg/node/peers"
@@ -110,4 +111,38 @@ func TestApp_PeersAll(t *testing.T) {
 	addresses := []string{out.Peers[0].Address}
 	assert.ElementsMatch(t, []string{"/5.3.6.7:6868"}, addresses)
 	assert.NotZero(t, out.Peers[0].LastSeen)
+}
+
+func TestApp_PeersBlackList(t *testing.T) {
+	peerManager := peers.NewMockPeerManager(t)
+
+	const (
+		blacklistedAddr = "5.3.6.7:6868"
+		requestID       = "request-123"
+		clientIP        = "192.168.1.1"
+	)
+
+	peerManager.EXPECT().AddToBlackListByAddr(
+		mock.MatchedBy(func(addr proto.TCPAddr) bool {
+			return addr.String() == blacklistedAddr
+		}),
+		mock.MatchedBy(func(t time.Time) bool {
+			return !t.IsZero()
+		}),
+		mock.MatchedBy(func(reason string) bool {
+			return reason != ""
+		}),
+	).Return()
+
+	cfg := &settings.BlockchainSettings{
+		FunctionalitySettings: settings.FunctionalitySettings{
+			GenerationPeriod: 0,
+		},
+	}
+
+	app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+	require.NoError(t, err)
+
+	err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
+	require.NoError(t, err)
 }

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -33,7 +33,7 @@ func TestApp_PeersKnown(t *testing.T) {
 	require.Len(t, rs2.Peers, 1)
 }
 
-func TestApp_PeersBlackList(t *testing.T) {
+func TestApp_PeersBlackListed(t *testing.T) {
 	peerManager := peers.NewMockPeerManager(t)
 
 	now := time.Now()

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -171,6 +171,7 @@ func (a *NodeApi) routes(opts *RunOptions) (chi.Router, error) {
 			rAuth.Post("/print", wrapper(a.debugPrint))
 			rAuth.Post("/rollback", wrapper(a.RollbackToHeight))
 			rAuth.Post("/rollback-to/{id}", wrapper(a.RollbackTo))
+			rAuth.Post("/blacklist", wrapper(a.PeersBlackList))
 		})
 		r.Route("/node", func(r chi.Router) {
 			r.Get("/version", wrapper(a.version))

--- a/pkg/blockchaininfo/mocks_test.go
+++ b/pkg/blockchaininfo/mocks_test.go
@@ -111,7 +111,7 @@ type MockUpdatesPublisherInterface_PublishUpdates_Call struct {
 //   - nc *nats.Conn
 //   - scheme proto.Scheme
 //   - l2ContractAddress string
-func (_e *MockUpdatesPublisherInterface_Expecter) PublishUpdates(ctx interface{}, updates interface{}, nc interface{}, scheme interface{}, l2ContractAddress interface{}) *MockUpdatesPublisherInterface_PublishUpdates_Call {
+func (_e *MockUpdatesPublisherInterface_Expecter) PublishUpdates(ctx any, updates any, nc any, scheme any, l2ContractAddress any) *MockUpdatesPublisherInterface_PublishUpdates_Call {
 	return &MockUpdatesPublisherInterface_PublishUpdates_Call{Call: _e.mock.On("PublishUpdates", ctx, updates, nc, scheme, l2ContractAddress)}
 }
 

--- a/pkg/consensus/mock_state_info_provider_test.go
+++ b/pkg/consensus/mock_state_info_provider_test.go
@@ -71,7 +71,7 @@ type MockstateInfoProvider_HeaderByHeight_Call struct {
 
 // HeaderByHeight is a helper method to define mock.On call
 //   - height uint64
-func (_e *MockstateInfoProvider_Expecter) HeaderByHeight(height interface{}) *MockstateInfoProvider_HeaderByHeight_Call {
+func (_e *MockstateInfoProvider_Expecter) HeaderByHeight(height any) *MockstateInfoProvider_HeaderByHeight_Call {
 	return &MockstateInfoProvider_HeaderByHeight_Call{Call: _e.mock.On("HeaderByHeight", height)}
 }
 
@@ -131,7 +131,7 @@ type MockstateInfoProvider_NewestAccountHasScript_Call struct {
 
 // NewestAccountHasScript is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockstateInfoProvider_Expecter) NewestAccountHasScript(addr interface{}) *MockstateInfoProvider_NewestAccountHasScript_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestAccountHasScript(addr any) *MockstateInfoProvider_NewestAccountHasScript_Call {
 	return &MockstateInfoProvider_NewestAccountHasScript_Call{Call: _e.mock.On("NewestAccountHasScript", addr)}
 }
 
@@ -191,7 +191,7 @@ type MockstateInfoProvider_NewestActivationHeight_Call struct {
 
 // NewestActivationHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockstateInfoProvider_Expecter) NewestActivationHeight(featureID interface{}) *MockstateInfoProvider_NewestActivationHeight_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestActivationHeight(featureID any) *MockstateInfoProvider_NewestActivationHeight_Call {
 	return &MockstateInfoProvider_NewestActivationHeight_Call{Call: _e.mock.On("NewestActivationHeight", featureID)}
 }
 
@@ -253,7 +253,7 @@ type MockstateInfoProvider_NewestHitSourceAtHeight_Call struct {
 
 // NewestHitSourceAtHeight is a helper method to define mock.On call
 //   - height uint64
-func (_e *MockstateInfoProvider_Expecter) NewestHitSourceAtHeight(height interface{}) *MockstateInfoProvider_NewestHitSourceAtHeight_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestHitSourceAtHeight(height any) *MockstateInfoProvider_NewestHitSourceAtHeight_Call {
 	return &MockstateInfoProvider_NewestHitSourceAtHeight_Call{Call: _e.mock.On("NewestHitSourceAtHeight", height)}
 }
 
@@ -314,7 +314,7 @@ type MockstateInfoProvider_NewestIsActiveAtHeight_Call struct {
 // NewestIsActiveAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height proto.Height
-func (_e *MockstateInfoProvider_Expecter) NewestIsActiveAtHeight(featureID interface{}, height interface{}) *MockstateInfoProvider_NewestIsActiveAtHeight_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestIsActiveAtHeight(featureID any, height any) *MockstateInfoProvider_NewestIsActiveAtHeight_Call {
 	return &MockstateInfoProvider_NewestIsActiveAtHeight_Call{Call: _e.mock.On("NewestIsActiveAtHeight", featureID, height)}
 }
 
@@ -380,7 +380,7 @@ type MockstateInfoProvider_NewestMinerGeneratingBalance_Call struct {
 // NewestMinerGeneratingBalance is a helper method to define mock.On call
 //   - header *proto.BlockHeader
 //   - height proto.Height
-func (_e *MockstateInfoProvider_Expecter) NewestMinerGeneratingBalance(header interface{}, height interface{}) *MockstateInfoProvider_NewestMinerGeneratingBalance_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestMinerGeneratingBalance(header any, height any) *MockstateInfoProvider_NewestMinerGeneratingBalance_Call {
 	return &MockstateInfoProvider_NewestMinerGeneratingBalance_Call{Call: _e.mock.On("NewestMinerGeneratingBalance", header, height)}
 }
 
@@ -437,7 +437,7 @@ type MockstateInfoProvider_NewestMinimalGeneratingBalanceAtHeight_Call struct {
 // NewestMinimalGeneratingBalanceAtHeight is a helper method to define mock.On call
 //   - height proto.Height
 //   - timestamp uint64
-func (_e *MockstateInfoProvider_Expecter) NewestMinimalGeneratingBalanceAtHeight(height interface{}, timestamp interface{}) *MockstateInfoProvider_NewestMinimalGeneratingBalanceAtHeight_Call {
+func (_e *MockstateInfoProvider_Expecter) NewestMinimalGeneratingBalanceAtHeight(height any, timestamp any) *MockstateInfoProvider_NewestMinimalGeneratingBalanceAtHeight_Call {
 	return &MockstateInfoProvider_NewestMinimalGeneratingBalanceAtHeight_Call{Call: _e.mock.On("NewestMinimalGeneratingBalanceAtHeight", height, timestamp)}
 }
 

--- a/pkg/grpc/server/mock_grpc_handlers_test.go
+++ b/pkg/grpc/server/mock_grpc_handlers_test.go
@@ -78,7 +78,7 @@ type MockGrpcHandlers_Broadcast_Call struct {
 // Broadcast is a helper method to define mock.On call
 //   - context1 context.Context
 //   - signedTransaction *waves.SignedTransaction
-func (_e *MockGrpcHandlers_Expecter) Broadcast(context1 interface{}, signedTransaction interface{}) *MockGrpcHandlers_Broadcast_Call {
+func (_e *MockGrpcHandlers_Expecter) Broadcast(context1 any, signedTransaction any) *MockGrpcHandlers_Broadcast_Call {
 	return &MockGrpcHandlers_Broadcast_Call{Call: _e.mock.On("Broadcast", context1, signedTransaction)}
 }
 
@@ -146,7 +146,7 @@ type MockGrpcHandlers_GetActivationStatus_Call struct {
 // GetActivationStatus is a helper method to define mock.On call
 //   - context1 context.Context
 //   - activationStatusRequest *grpc.ActivationStatusRequest
-func (_e *MockGrpcHandlers_Expecter) GetActivationStatus(context1 interface{}, activationStatusRequest interface{}) *MockGrpcHandlers_GetActivationStatus_Call {
+func (_e *MockGrpcHandlers_Expecter) GetActivationStatus(context1 any, activationStatusRequest any) *MockGrpcHandlers_GetActivationStatus_Call {
 	return &MockGrpcHandlers_GetActivationStatus_Call{Call: _e.mock.On("GetActivationStatus", context1, activationStatusRequest)}
 }
 
@@ -203,7 +203,7 @@ type MockGrpcHandlers_GetActiveLeases_Call struct {
 // GetActiveLeases is a helper method to define mock.On call
 //   - accountRequest *grpc.AccountRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.LeaseResponse]
-func (_e *MockGrpcHandlers_Expecter) GetActiveLeases(accountRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetActiveLeases_Call {
+func (_e *MockGrpcHandlers_Expecter) GetActiveLeases(accountRequest any, serverStreamingServer any) *MockGrpcHandlers_GetActiveLeases_Call {
 	return &MockGrpcHandlers_GetActiveLeases_Call{Call: _e.mock.On("GetActiveLeases", accountRequest, serverStreamingServer)}
 }
 
@@ -260,7 +260,7 @@ type MockGrpcHandlers_GetBalances_Call struct {
 // GetBalances is a helper method to define mock.On call
 //   - balancesRequest *grpc.BalancesRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.BalanceResponse]
-func (_e *MockGrpcHandlers_Expecter) GetBalances(balancesRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetBalances_Call {
+func (_e *MockGrpcHandlers_Expecter) GetBalances(balancesRequest any, serverStreamingServer any) *MockGrpcHandlers_GetBalances_Call {
 	return &MockGrpcHandlers_GetBalances_Call{Call: _e.mock.On("GetBalances", balancesRequest, serverStreamingServer)}
 }
 
@@ -328,7 +328,7 @@ type MockGrpcHandlers_GetBaseTarget_Call struct {
 // GetBaseTarget is a helper method to define mock.On call
 //   - context1 context.Context
 //   - empty *emptypb.Empty
-func (_e *MockGrpcHandlers_Expecter) GetBaseTarget(context1 interface{}, empty interface{}) *MockGrpcHandlers_GetBaseTarget_Call {
+func (_e *MockGrpcHandlers_Expecter) GetBaseTarget(context1 any, empty any) *MockGrpcHandlers_GetBaseTarget_Call {
 	return &MockGrpcHandlers_GetBaseTarget_Call{Call: _e.mock.On("GetBaseTarget", context1, empty)}
 }
 
@@ -396,7 +396,7 @@ type MockGrpcHandlers_GetBlock_Call struct {
 // GetBlock is a helper method to define mock.On call
 //   - context1 context.Context
 //   - blockRequest *grpc.BlockRequest
-func (_e *MockGrpcHandlers_Expecter) GetBlock(context1 interface{}, blockRequest interface{}) *MockGrpcHandlers_GetBlock_Call {
+func (_e *MockGrpcHandlers_Expecter) GetBlock(context1 any, blockRequest any) *MockGrpcHandlers_GetBlock_Call {
 	return &MockGrpcHandlers_GetBlock_Call{Call: _e.mock.On("GetBlock", context1, blockRequest)}
 }
 
@@ -453,7 +453,7 @@ type MockGrpcHandlers_GetBlockRange_Call struct {
 // GetBlockRange is a helper method to define mock.On call
 //   - blockRangeRequest *grpc.BlockRangeRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.BlockWithHeight]
-func (_e *MockGrpcHandlers_Expecter) GetBlockRange(blockRangeRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetBlockRange_Call {
+func (_e *MockGrpcHandlers_Expecter) GetBlockRange(blockRangeRequest any, serverStreamingServer any) *MockGrpcHandlers_GetBlockRange_Call {
 	return &MockGrpcHandlers_GetBlockRange_Call{Call: _e.mock.On("GetBlockRange", blockRangeRequest, serverStreamingServer)}
 }
 
@@ -521,7 +521,7 @@ type MockGrpcHandlers_GetCumulativeScore_Call struct {
 // GetCumulativeScore is a helper method to define mock.On call
 //   - context1 context.Context
 //   - empty *emptypb.Empty
-func (_e *MockGrpcHandlers_Expecter) GetCumulativeScore(context1 interface{}, empty interface{}) *MockGrpcHandlers_GetCumulativeScore_Call {
+func (_e *MockGrpcHandlers_Expecter) GetCumulativeScore(context1 any, empty any) *MockGrpcHandlers_GetCumulativeScore_Call {
 	return &MockGrpcHandlers_GetCumulativeScore_Call{Call: _e.mock.On("GetCumulativeScore", context1, empty)}
 }
 
@@ -589,7 +589,7 @@ type MockGrpcHandlers_GetCurrentHeight_Call struct {
 // GetCurrentHeight is a helper method to define mock.On call
 //   - context1 context.Context
 //   - empty *emptypb.Empty
-func (_e *MockGrpcHandlers_Expecter) GetCurrentHeight(context1 interface{}, empty interface{}) *MockGrpcHandlers_GetCurrentHeight_Call {
+func (_e *MockGrpcHandlers_Expecter) GetCurrentHeight(context1 any, empty any) *MockGrpcHandlers_GetCurrentHeight_Call {
 	return &MockGrpcHandlers_GetCurrentHeight_Call{Call: _e.mock.On("GetCurrentHeight", context1, empty)}
 }
 
@@ -646,7 +646,7 @@ type MockGrpcHandlers_GetDataEntries_Call struct {
 // GetDataEntries is a helper method to define mock.On call
 //   - dataRequest *grpc.DataRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.DataEntryResponse]
-func (_e *MockGrpcHandlers_Expecter) GetDataEntries(dataRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetDataEntries_Call {
+func (_e *MockGrpcHandlers_Expecter) GetDataEntries(dataRequest any, serverStreamingServer any) *MockGrpcHandlers_GetDataEntries_Call {
 	return &MockGrpcHandlers_GetDataEntries_Call{Call: _e.mock.On("GetDataEntries", dataRequest, serverStreamingServer)}
 }
 
@@ -714,7 +714,7 @@ type MockGrpcHandlers_GetInfo_Call struct {
 // GetInfo is a helper method to define mock.On call
 //   - context1 context.Context
 //   - assetRequest *grpc.AssetRequest
-func (_e *MockGrpcHandlers_Expecter) GetInfo(context1 interface{}, assetRequest interface{}) *MockGrpcHandlers_GetInfo_Call {
+func (_e *MockGrpcHandlers_Expecter) GetInfo(context1 any, assetRequest any) *MockGrpcHandlers_GetInfo_Call {
 	return &MockGrpcHandlers_GetInfo_Call{Call: _e.mock.On("GetInfo", context1, assetRequest)}
 }
 
@@ -771,7 +771,7 @@ type MockGrpcHandlers_GetNFTList_Call struct {
 // GetNFTList is a helper method to define mock.On call
 //   - nFTRequest *grpc.NFTRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.NFTResponse]
-func (_e *MockGrpcHandlers_Expecter) GetNFTList(nFTRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetNFTList_Call {
+func (_e *MockGrpcHandlers_Expecter) GetNFTList(nFTRequest any, serverStreamingServer any) *MockGrpcHandlers_GetNFTList_Call {
 	return &MockGrpcHandlers_GetNFTList_Call{Call: _e.mock.On("GetNFTList", nFTRequest, serverStreamingServer)}
 }
 
@@ -839,7 +839,7 @@ type MockGrpcHandlers_GetScript_Call struct {
 // GetScript is a helper method to define mock.On call
 //   - context1 context.Context
 //   - accountRequest *grpc.AccountRequest
-func (_e *MockGrpcHandlers_Expecter) GetScript(context1 interface{}, accountRequest interface{}) *MockGrpcHandlers_GetScript_Call {
+func (_e *MockGrpcHandlers_Expecter) GetScript(context1 any, accountRequest any) *MockGrpcHandlers_GetScript_Call {
 	return &MockGrpcHandlers_GetScript_Call{Call: _e.mock.On("GetScript", context1, accountRequest)}
 }
 
@@ -896,7 +896,7 @@ type MockGrpcHandlers_GetStateChanges_Call struct {
 // GetStateChanges is a helper method to define mock.On call
 //   - transactionsRequest *grpc.TransactionsRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.InvokeScriptResultResponse]
-func (_e *MockGrpcHandlers_Expecter) GetStateChanges(transactionsRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetStateChanges_Call {
+func (_e *MockGrpcHandlers_Expecter) GetStateChanges(transactionsRequest any, serverStreamingServer any) *MockGrpcHandlers_GetStateChanges_Call {
 	return &MockGrpcHandlers_GetStateChanges_Call{Call: _e.mock.On("GetStateChanges", transactionsRequest, serverStreamingServer)}
 }
 
@@ -953,7 +953,7 @@ type MockGrpcHandlers_GetStatuses_Call struct {
 // GetStatuses is a helper method to define mock.On call
 //   - transactionsByIdRequest *grpc.TransactionsByIdRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.TransactionStatus]
-func (_e *MockGrpcHandlers_Expecter) GetStatuses(transactionsByIdRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetStatuses_Call {
+func (_e *MockGrpcHandlers_Expecter) GetStatuses(transactionsByIdRequest any, serverStreamingServer any) *MockGrpcHandlers_GetStatuses_Call {
 	return &MockGrpcHandlers_GetStatuses_Call{Call: _e.mock.On("GetStatuses", transactionsByIdRequest, serverStreamingServer)}
 }
 
@@ -1010,7 +1010,7 @@ type MockGrpcHandlers_GetTransactionSnapshots_Call struct {
 // GetTransactionSnapshots is a helper method to define mock.On call
 //   - transactionSnapshotsRequest *grpc.TransactionSnapshotsRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.TransactionSnapshotResponse]
-func (_e *MockGrpcHandlers_Expecter) GetTransactionSnapshots(transactionSnapshotsRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetTransactionSnapshots_Call {
+func (_e *MockGrpcHandlers_Expecter) GetTransactionSnapshots(transactionSnapshotsRequest any, serverStreamingServer any) *MockGrpcHandlers_GetTransactionSnapshots_Call {
 	return &MockGrpcHandlers_GetTransactionSnapshots_Call{Call: _e.mock.On("GetTransactionSnapshots", transactionSnapshotsRequest, serverStreamingServer)}
 }
 
@@ -1067,7 +1067,7 @@ type MockGrpcHandlers_GetTransactions_Call struct {
 // GetTransactions is a helper method to define mock.On call
 //   - transactionsRequest *grpc.TransactionsRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.TransactionResponse]
-func (_e *MockGrpcHandlers_Expecter) GetTransactions(transactionsRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetTransactions_Call {
+func (_e *MockGrpcHandlers_Expecter) GetTransactions(transactionsRequest any, serverStreamingServer any) *MockGrpcHandlers_GetTransactions_Call {
 	return &MockGrpcHandlers_GetTransactions_Call{Call: _e.mock.On("GetTransactions", transactionsRequest, serverStreamingServer)}
 }
 
@@ -1124,7 +1124,7 @@ type MockGrpcHandlers_GetUnconfirmed_Call struct {
 // GetUnconfirmed is a helper method to define mock.On call
 //   - transactionsRequest *grpc.TransactionsRequest
 //   - serverStreamingServer grpc0.ServerStreamingServer[grpc.TransactionResponse]
-func (_e *MockGrpcHandlers_Expecter) GetUnconfirmed(transactionsRequest interface{}, serverStreamingServer interface{}) *MockGrpcHandlers_GetUnconfirmed_Call {
+func (_e *MockGrpcHandlers_Expecter) GetUnconfirmed(transactionsRequest any, serverStreamingServer any) *MockGrpcHandlers_GetUnconfirmed_Call {
 	return &MockGrpcHandlers_GetUnconfirmed_Call{Call: _e.mock.On("GetUnconfirmed", transactionsRequest, serverStreamingServer)}
 }
 
@@ -1192,7 +1192,7 @@ type MockGrpcHandlers_ResolveAlias_Call struct {
 // ResolveAlias is a helper method to define mock.On call
 //   - context1 context.Context
 //   - stringValue *wrapperspb.StringValue
-func (_e *MockGrpcHandlers_Expecter) ResolveAlias(context1 interface{}, stringValue interface{}) *MockGrpcHandlers_ResolveAlias_Call {
+func (_e *MockGrpcHandlers_Expecter) ResolveAlias(context1 any, stringValue any) *MockGrpcHandlers_ResolveAlias_Call {
 	return &MockGrpcHandlers_ResolveAlias_Call{Call: _e.mock.On("ResolveAlias", context1, stringValue)}
 }
 
@@ -1260,7 +1260,7 @@ type MockGrpcHandlers_Sign_Call struct {
 // Sign is a helper method to define mock.On call
 //   - context1 context.Context
 //   - signRequest *grpc.SignRequest
-func (_e *MockGrpcHandlers_Expecter) Sign(context1 interface{}, signRequest interface{}) *MockGrpcHandlers_Sign_Call {
+func (_e *MockGrpcHandlers_Expecter) Sign(context1 any, signRequest any) *MockGrpcHandlers_Sign_Call {
 	return &MockGrpcHandlers_Sign_Call{Call: _e.mock.On("Sign", context1, signRequest)}
 }
 

--- a/pkg/networking/mocks_test.go
+++ b/pkg/networking/mocks_test.go
@@ -50,7 +50,7 @@ type MockHandler_OnClose_Call struct {
 
 // OnClose is a helper method to define mock.On call
 //   - endpointWriter EndpointWriter
-func (_e *MockHandler_Expecter) OnClose(endpointWriter interface{}) *MockHandler_OnClose_Call {
+func (_e *MockHandler_Expecter) OnClose(endpointWriter any) *MockHandler_OnClose_Call {
 	return &MockHandler_OnClose_Call{Call: _e.mock.On("OnClose", endpointWriter)}
 }
 
@@ -91,7 +91,7 @@ type MockHandler_OnFailure_Call struct {
 // OnFailure is a helper method to define mock.On call
 //   - endpointWriter EndpointWriter
 //   - err error
-func (_e *MockHandler_Expecter) OnFailure(endpointWriter interface{}, err interface{}) *MockHandler_OnFailure_Call {
+func (_e *MockHandler_Expecter) OnFailure(endpointWriter any, err any) *MockHandler_OnFailure_Call {
 	return &MockHandler_OnFailure_Call{Call: _e.mock.On("OnFailure", endpointWriter, err)}
 }
 
@@ -137,7 +137,7 @@ type MockHandler_OnHandshake_Call struct {
 // OnHandshake is a helper method to define mock.On call
 //   - endpointWriter EndpointWriter
 //   - handshake Handshake
-func (_e *MockHandler_Expecter) OnHandshake(endpointWriter interface{}, handshake interface{}) *MockHandler_OnHandshake_Call {
+func (_e *MockHandler_Expecter) OnHandshake(endpointWriter any, handshake any) *MockHandler_OnHandshake_Call {
 	return &MockHandler_OnHandshake_Call{Call: _e.mock.On("OnHandshake", endpointWriter, handshake)}
 }
 
@@ -183,7 +183,7 @@ type MockHandler_OnHandshakeFailed_Call struct {
 // OnHandshakeFailed is a helper method to define mock.On call
 //   - endpointWriter EndpointWriter
 //   - handshake Handshake
-func (_e *MockHandler_Expecter) OnHandshakeFailed(endpointWriter interface{}, handshake interface{}) *MockHandler_OnHandshakeFailed_Call {
+func (_e *MockHandler_Expecter) OnHandshakeFailed(endpointWriter any, handshake any) *MockHandler_OnHandshakeFailed_Call {
 	return &MockHandler_OnHandshakeFailed_Call{Call: _e.mock.On("OnHandshakeFailed", endpointWriter, handshake)}
 }
 
@@ -229,7 +229,7 @@ type MockHandler_OnReceive_Call struct {
 // OnReceive is a helper method to define mock.On call
 //   - endpointWriter EndpointWriter
 //   - reader io.Reader
-func (_e *MockHandler_Expecter) OnReceive(endpointWriter interface{}, reader interface{}) *MockHandler_OnReceive_Call {
+func (_e *MockHandler_Expecter) OnReceive(endpointWriter any, reader any) *MockHandler_OnReceive_Call {
 	return &MockHandler_OnReceive_Call{Call: _e.mock.On("OnReceive", endpointWriter, reader)}
 }
 
@@ -409,7 +409,7 @@ type MockHeader_ReadFrom_Call struct {
 
 // ReadFrom is a helper method to define mock.On call
 //   - r io.Reader
-func (_e *MockHeader_Expecter) ReadFrom(r interface{}) *MockHeader_ReadFrom_Call {
+func (_e *MockHeader_Expecter) ReadFrom(r any) *MockHeader_ReadFrom_Call {
 	return &MockHeader_ReadFrom_Call{Call: _e.mock.On("ReadFrom", r)}
 }
 
@@ -469,7 +469,7 @@ type MockHeader_WriteTo_Call struct {
 
 // WriteTo is a helper method to define mock.On call
 //   - w io.Writer
-func (_e *MockHeader_Expecter) WriteTo(w interface{}) *MockHeader_WriteTo_Call {
+func (_e *MockHeader_Expecter) WriteTo(w any) *MockHeader_WriteTo_Call {
 	return &MockHeader_WriteTo_Call{Call: _e.mock.On("WriteTo", w)}
 }
 
@@ -640,7 +640,7 @@ type MockProtocol_IsAcceptableHandshake_Call struct {
 // IsAcceptableHandshake is a helper method to define mock.On call
 //   - session *Session
 //   - handshake Handshake
-func (_e *MockProtocol_Expecter) IsAcceptableHandshake(session interface{}, handshake interface{}) *MockProtocol_IsAcceptableHandshake_Call {
+func (_e *MockProtocol_Expecter) IsAcceptableHandshake(session any, handshake any) *MockProtocol_IsAcceptableHandshake_Call {
 	return &MockProtocol_IsAcceptableHandshake_Call{Call: _e.mock.On("IsAcceptableHandshake", session, handshake)}
 }
 
@@ -697,7 +697,7 @@ type MockProtocol_IsAcceptableMessage_Call struct {
 // IsAcceptableMessage is a helper method to define mock.On call
 //   - session *Session
 //   - header Header
-func (_e *MockProtocol_Expecter) IsAcceptableMessage(session interface{}, header interface{}) *MockProtocol_IsAcceptableMessage_Call {
+func (_e *MockProtocol_Expecter) IsAcceptableMessage(session any, header any) *MockProtocol_IsAcceptableMessage_Call {
 	return &MockProtocol_IsAcceptableMessage_Call{Call: _e.mock.On("IsAcceptableMessage", session, header)}
 }
 

--- a/pkg/node/peers/mock_peer_manager.go
+++ b/pkg/node/peers/mock_peer_manager.go
@@ -57,7 +57,7 @@ type MockPeerManager_AddToBlackList_Call struct {
 //   - peer1 peer.Peer
 //   - blockTime time.Time
 //   - reason string
-func (_e *MockPeerManager_Expecter) AddToBlackList(peer1 interface{}, blockTime interface{}, reason interface{}) *MockPeerManager_AddToBlackList_Call {
+func (_e *MockPeerManager_Expecter) AddToBlackList(peer1 any, blockTime any, reason any) *MockPeerManager_AddToBlackList_Call {
 	return &MockPeerManager_AddToBlackList_Call{Call: _e.mock.On("AddToBlackList", peer1, blockTime, reason)}
 }
 
@@ -90,6 +90,58 @@ func (_c *MockPeerManager_AddToBlackList_Call) Return() *MockPeerManager_AddToBl
 }
 
 func (_c *MockPeerManager_AddToBlackList_Call) RunAndReturn(run func(peer1 peer.Peer, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackList_Call {
+	_c.Run(run)
+	return _c
+}
+
+// AddToBlackListByAddr provides a mock function for the type MockPeerManager
+func (_mock *MockPeerManager) AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string) {
+	_mock.Called(addr, blockTime, reason)
+	return
+}
+
+// MockPeerManager_AddToBlackListByAddr_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBlackListByAddr'
+type MockPeerManager_AddToBlackListByAddr_Call struct {
+	*mock.Call
+}
+
+// AddToBlackListByAddr is a helper method to define mock.On call
+//   - addr proto.TCPAddr
+//   - blockTime time.Time
+//   - reason string
+func (_e *MockPeerManager_Expecter) AddToBlackListByAddr(addr any, blockTime any, reason any) *MockPeerManager_AddToBlackListByAddr_Call {
+	return &MockPeerManager_AddToBlackListByAddr_Call{Call: _e.mock.On("AddToBlackListByAddr", addr, blockTime, reason)}
+}
+
+func (_c *MockPeerManager_AddToBlackListByAddr_Call) Run(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByAddr_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 proto.TCPAddr
+		if args[0] != nil {
+			arg0 = args[0].(proto.TCPAddr)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPeerManager_AddToBlackListByAddr_Call) Return() *MockPeerManager_AddToBlackListByAddr_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockPeerManager_AddToBlackListByAddr_Call) RunAndReturn(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByAddr_Call {
 	_c.Run(run)
 	return _c
 }
@@ -208,7 +260,7 @@ type MockPeerManager_CheckPeerInLargestScoreGroup_Call struct {
 
 // CheckPeerInLargestScoreGroup is a helper method to define mock.On call
 //   - p peer.Peer
-func (_e *MockPeerManager_Expecter) CheckPeerInLargestScoreGroup(p interface{}) *MockPeerManager_CheckPeerInLargestScoreGroup_Call {
+func (_e *MockPeerManager_Expecter) CheckPeerInLargestScoreGroup(p any) *MockPeerManager_CheckPeerInLargestScoreGroup_Call {
 	return &MockPeerManager_CheckPeerInLargestScoreGroup_Call{Call: _e.mock.On("CheckPeerInLargestScoreGroup", p)}
 }
 
@@ -270,7 +322,7 @@ type MockPeerManager_CheckPeerWithMaxScore_Call struct {
 
 // CheckPeerWithMaxScore is a helper method to define mock.On call
 //   - p peer.Peer
-func (_e *MockPeerManager_Expecter) CheckPeerWithMaxScore(p interface{}) *MockPeerManager_CheckPeerWithMaxScore_Call {
+func (_e *MockPeerManager_Expecter) CheckPeerWithMaxScore(p any) *MockPeerManager_CheckPeerWithMaxScore_Call {
 	return &MockPeerManager_CheckPeerWithMaxScore_Call{Call: _e.mock.On("CheckPeerWithMaxScore", p)}
 }
 
@@ -410,7 +462,7 @@ type MockPeerManager_Connect_Call struct {
 // Connect is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tCPAddr proto.TCPAddr
-func (_e *MockPeerManager_Expecter) Connect(context1 interface{}, tCPAddr interface{}) *MockPeerManager_Connect_Call {
+func (_e *MockPeerManager_Expecter) Connect(context1 any, tCPAddr any) *MockPeerManager_Connect_Call {
 	return &MockPeerManager_Connect_Call{Call: _e.mock.On("Connect", context1, tCPAddr)}
 }
 
@@ -499,7 +551,7 @@ type MockPeerManager_Disconnect_Call struct {
 
 // Disconnect is a helper method to define mock.On call
 //   - peer1 peer.Peer
-func (_e *MockPeerManager_Expecter) Disconnect(peer1 interface{}) *MockPeerManager_Disconnect_Call {
+func (_e *MockPeerManager_Expecter) Disconnect(peer1 any) *MockPeerManager_Disconnect_Call {
 	return &MockPeerManager_Disconnect_Call{Call: _e.mock.On("Disconnect", peer1)}
 }
 
@@ -539,7 +591,7 @@ type MockPeerManager_EachConnected_Call struct {
 
 // EachConnected is a helper method to define mock.On call
 //   - fn func(peer.Peer, *proto.Score)
-func (_e *MockPeerManager_Expecter) EachConnected(fn interface{}) *MockPeerManager_EachConnected_Call {
+func (_e *MockPeerManager_Expecter) EachConnected(fn any) *MockPeerManager_EachConnected_Call {
 	return &MockPeerManager_EachConnected_Call{Call: _e.mock.On("EachConnected", fn)}
 }
 
@@ -636,7 +688,7 @@ type MockPeerManager_NewConnection_Call struct {
 
 // NewConnection is a helper method to define mock.On call
 //   - peer1 peer.Peer
-func (_e *MockPeerManager_Expecter) NewConnection(peer1 interface{}) *MockPeerManager_NewConnection_Call {
+func (_e *MockPeerManager_Expecter) NewConnection(peer1 any) *MockPeerManager_NewConnection_Call {
 	return &MockPeerManager_NewConnection_Call{Call: _e.mock.On("NewConnection", peer1)}
 }
 
@@ -698,7 +750,7 @@ type MockPeerManager_Score_Call struct {
 
 // Score is a helper method to define mock.On call
 //   - p peer.Peer
-func (_e *MockPeerManager_Expecter) Score(p interface{}) *MockPeerManager_Score_Call {
+func (_e *MockPeerManager_Expecter) Score(p any) *MockPeerManager_Score_Call {
 	return &MockPeerManager_Score_Call{Call: _e.mock.On("Score", p)}
 }
 
@@ -750,7 +802,7 @@ type MockPeerManager_SpawnIncomingConnection_Call struct {
 // SpawnIncomingConnection is a helper method to define mock.On call
 //   - ctx context.Context
 //   - conn net.Conn
-func (_e *MockPeerManager_Expecter) SpawnIncomingConnection(ctx interface{}, conn interface{}) *MockPeerManager_SpawnIncomingConnection_Call {
+func (_e *MockPeerManager_Expecter) SpawnIncomingConnection(ctx any, conn any) *MockPeerManager_SpawnIncomingConnection_Call {
 	return &MockPeerManager_SpawnIncomingConnection_Call{Call: _e.mock.On("SpawnIncomingConnection", ctx, conn)}
 }
 
@@ -795,7 +847,7 @@ type MockPeerManager_SpawnOutgoingConnections_Call struct {
 
 // SpawnOutgoingConnections is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *MockPeerManager_Expecter) SpawnOutgoingConnections(context1 interface{}) *MockPeerManager_SpawnOutgoingConnections_Call {
+func (_e *MockPeerManager_Expecter) SpawnOutgoingConnections(context1 any) *MockPeerManager_SpawnOutgoingConnections_Call {
 	return &MockPeerManager_SpawnOutgoingConnections_Call{Call: _e.mock.On("SpawnOutgoingConnections", context1)}
 }
 
@@ -892,7 +944,7 @@ type MockPeerManager_UpdateKnownPeers_Call struct {
 
 // UpdateKnownPeers is a helper method to define mock.On call
 //   - knownPeers []storage.KnownPeer
-func (_e *MockPeerManager_Expecter) UpdateKnownPeers(knownPeers interface{}) *MockPeerManager_UpdateKnownPeers_Call {
+func (_e *MockPeerManager_Expecter) UpdateKnownPeers(knownPeers any) *MockPeerManager_UpdateKnownPeers_Call {
 	return &MockPeerManager_UpdateKnownPeers_Call{Call: _e.mock.On("UpdateKnownPeers", knownPeers)}
 }
 
@@ -944,7 +996,7 @@ type MockPeerManager_UpdateScore_Call struct {
 // UpdateScore is a helper method to define mock.On call
 //   - p peer.Peer
 //   - score *proto.Score
-func (_e *MockPeerManager_Expecter) UpdateScore(p interface{}, score interface{}) *MockPeerManager_UpdateScore_Call {
+func (_e *MockPeerManager_Expecter) UpdateScore(p any, score any) *MockPeerManager_UpdateScore_Call {
 	return &MockPeerManager_UpdateScore_Call{Call: _e.mock.On("UpdateScore", p, score)}
 }
 

--- a/pkg/node/peers/mock_peer_storage_test.go
+++ b/pkg/node/peers/mock_peer_storage_test.go
@@ -63,7 +63,7 @@ type MockPeerStorage_AddOrUpdateKnown_Call struct {
 // AddOrUpdateKnown is a helper method to define mock.On call
 //   - known []storage.KnownPeer
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) AddOrUpdateKnown(known interface{}, now interface{}) *MockPeerStorage_AddOrUpdateKnown_Call {
+func (_e *MockPeerStorage_Expecter) AddOrUpdateKnown(known any, now any) *MockPeerStorage_AddOrUpdateKnown_Call {
 	return &MockPeerStorage_AddOrUpdateKnown_Call{Call: _e.mock.On("AddOrUpdateKnown", known, now)}
 }
 
@@ -119,7 +119,7 @@ type MockPeerStorage_AddSuspended_Call struct {
 
 // AddSuspended is a helper method to define mock.On call
 //   - suspended []storage.SuspendedPeer
-func (_e *MockPeerStorage_Expecter) AddSuspended(suspended interface{}) *MockPeerStorage_AddSuspended_Call {
+func (_e *MockPeerStorage_Expecter) AddSuspended(suspended any) *MockPeerStorage_AddSuspended_Call {
 	return &MockPeerStorage_AddSuspended_Call{Call: _e.mock.On("AddSuspended", suspended)}
 }
 
@@ -170,7 +170,7 @@ type MockPeerStorage_AddToBlackList_Call struct {
 
 // AddToBlackList is a helper method to define mock.On call
 //   - blackListed []storage.BlackListedPeer
-func (_e *MockPeerStorage_Expecter) AddToBlackList(blackListed interface{}) *MockPeerStorage_AddToBlackList_Call {
+func (_e *MockPeerStorage_Expecter) AddToBlackList(blackListed any) *MockPeerStorage_AddToBlackList_Call {
 	return &MockPeerStorage_AddToBlackList_Call{Call: _e.mock.On("AddToBlackList", blackListed)}
 }
 
@@ -223,7 +223,7 @@ type MockPeerStorage_BlackList_Call struct {
 
 // BlackList is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) BlackList(now interface{}) *MockPeerStorage_BlackList_Call {
+func (_e *MockPeerStorage_Expecter) BlackList(now any) *MockPeerStorage_BlackList_Call {
 	return &MockPeerStorage_BlackList_Call{Call: _e.mock.On("BlackList", now)}
 }
 
@@ -274,7 +274,7 @@ type MockPeerStorage_DeleteBlackListedByIP_Call struct {
 
 // DeleteBlackListedByIP is a helper method to define mock.On call
 //   - blackListed []storage.BlackListedPeer
-func (_e *MockPeerStorage_Expecter) DeleteBlackListedByIP(blackListed interface{}) *MockPeerStorage_DeleteBlackListedByIP_Call {
+func (_e *MockPeerStorage_Expecter) DeleteBlackListedByIP(blackListed any) *MockPeerStorage_DeleteBlackListedByIP_Call {
 	return &MockPeerStorage_DeleteBlackListedByIP_Call{Call: _e.mock.On("DeleteBlackListedByIP", blackListed)}
 }
 
@@ -325,7 +325,7 @@ type MockPeerStorage_DeleteKnown_Call struct {
 
 // DeleteKnown is a helper method to define mock.On call
 //   - known []storage.KnownPeer
-func (_e *MockPeerStorage_Expecter) DeleteKnown(known interface{}) *MockPeerStorage_DeleteKnown_Call {
+func (_e *MockPeerStorage_Expecter) DeleteKnown(known any) *MockPeerStorage_DeleteKnown_Call {
 	return &MockPeerStorage_DeleteKnown_Call{Call: _e.mock.On("DeleteKnown", known)}
 }
 
@@ -376,7 +376,7 @@ type MockPeerStorage_DeleteSuspendedByIP_Call struct {
 
 // DeleteSuspendedByIP is a helper method to define mock.On call
 //   - suspended []storage.SuspendedPeer
-func (_e *MockPeerStorage_Expecter) DeleteSuspendedByIP(suspended interface{}) *MockPeerStorage_DeleteSuspendedByIP_Call {
+func (_e *MockPeerStorage_Expecter) DeleteSuspendedByIP(suspended any) *MockPeerStorage_DeleteSuspendedByIP_Call {
 	return &MockPeerStorage_DeleteSuspendedByIP_Call{Call: _e.mock.On("DeleteSuspendedByIP", suspended)}
 }
 
@@ -604,7 +604,7 @@ type MockPeerStorage_IsBlackListedIP_Call struct {
 // IsBlackListedIP is a helper method to define mock.On call
 //   - ip storage.IP
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) IsBlackListedIP(ip interface{}, now interface{}) *MockPeerStorage_IsBlackListedIP_Call {
+func (_e *MockPeerStorage_Expecter) IsBlackListedIP(ip any, now any) *MockPeerStorage_IsBlackListedIP_Call {
 	return &MockPeerStorage_IsBlackListedIP_Call{Call: _e.mock.On("IsBlackListedIP", ip, now)}
 }
 
@@ -663,7 +663,7 @@ type MockPeerStorage_IsBlackListedIPs_Call struct {
 // IsBlackListedIPs is a helper method to define mock.On call
 //   - ips []storage.IP
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) IsBlackListedIPs(ips interface{}, now interface{}) *MockPeerStorage_IsBlackListedIPs_Call {
+func (_e *MockPeerStorage_Expecter) IsBlackListedIPs(ips any, now any) *MockPeerStorage_IsBlackListedIPs_Call {
 	return &MockPeerStorage_IsBlackListedIPs_Call{Call: _e.mock.On("IsBlackListedIPs", ips, now)}
 }
 
@@ -720,7 +720,7 @@ type MockPeerStorage_IsSuspendedIP_Call struct {
 // IsSuspendedIP is a helper method to define mock.On call
 //   - ip storage.IP
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) IsSuspendedIP(ip interface{}, now interface{}) *MockPeerStorage_IsSuspendedIP_Call {
+func (_e *MockPeerStorage_Expecter) IsSuspendedIP(ip any, now any) *MockPeerStorage_IsSuspendedIP_Call {
 	return &MockPeerStorage_IsSuspendedIP_Call{Call: _e.mock.On("IsSuspendedIP", ip, now)}
 }
 
@@ -779,7 +779,7 @@ type MockPeerStorage_IsSuspendedIPs_Call struct {
 // IsSuspendedIPs is a helper method to define mock.On call
 //   - ips []storage.IP
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) IsSuspendedIPs(ips interface{}, now interface{}) *MockPeerStorage_IsSuspendedIPs_Call {
+func (_e *MockPeerStorage_Expecter) IsSuspendedIPs(ips any, now any) *MockPeerStorage_IsSuspendedIPs_Call {
 	return &MockPeerStorage_IsSuspendedIPs_Call{Call: _e.mock.On("IsSuspendedIPs", ips, now)}
 }
 
@@ -837,7 +837,7 @@ type MockPeerStorage_Known_Call struct {
 
 // Known is a helper method to define mock.On call
 //   - limit int
-func (_e *MockPeerStorage_Expecter) Known(limit interface{}) *MockPeerStorage_Known_Call {
+func (_e *MockPeerStorage_Expecter) Known(limit any) *MockPeerStorage_Known_Call {
 	return &MockPeerStorage_Known_Call{Call: _e.mock.On("Known", limit)}
 }
 
@@ -888,7 +888,7 @@ type MockPeerStorage_RefreshBlackList_Call struct {
 
 // RefreshBlackList is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) RefreshBlackList(now interface{}) *MockPeerStorage_RefreshBlackList_Call {
+func (_e *MockPeerStorage_Expecter) RefreshBlackList(now any) *MockPeerStorage_RefreshBlackList_Call {
 	return &MockPeerStorage_RefreshBlackList_Call{Call: _e.mock.On("RefreshBlackList", now)}
 }
 
@@ -939,7 +939,7 @@ type MockPeerStorage_RefreshSuspended_Call struct {
 
 // RefreshSuspended is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) RefreshSuspended(now interface{}) *MockPeerStorage_RefreshSuspended_Call {
+func (_e *MockPeerStorage_Expecter) RefreshSuspended(now any) *MockPeerStorage_RefreshSuspended_Call {
 	return &MockPeerStorage_RefreshSuspended_Call{Call: _e.mock.On("RefreshSuspended", now)}
 }
 
@@ -992,7 +992,7 @@ type MockPeerStorage_Suspended_Call struct {
 
 // Suspended is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockPeerStorage_Expecter) Suspended(now interface{}) *MockPeerStorage_Suspended_Call {
+func (_e *MockPeerStorage_Expecter) Suspended(now any) *MockPeerStorage_Suspended_Call {
 	return &MockPeerStorage_Suspended_Call{Call: _e.mock.On("Suspended", now)}
 }
 

--- a/pkg/node/peers/peer_manager.go
+++ b/pkg/node/peers/peer_manager.go
@@ -49,6 +49,7 @@ type PeerManager interface {
 	ConnectedCount() int
 	EachConnected(func(peer.Peer, *proto.Score))
 	AddToBlackList(peer peer.Peer, blockTime time.Time, reason string)
+	AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string)
 	BlackList() []storage.BlackListedPeer
 	ClearBlackList() error
 	UpdateScore(p peer.Peer, score *proto.Score) error
@@ -174,25 +175,60 @@ func (a *PeerManagerImpl) EachConnected(f func(peer peer.Peer, score *big.Int)) 
 	)
 }
 
+func (a *PeerManagerImpl) AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string) {
+	if a.blackListDuration <= 0 {
+		return
+	}
+	if addr.Empty() {
+		return // no need to add empty address to black list
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	ip := storage.IpFromIpPort(addr.ToIpPort())
+	var toDisconnectActivePeers []peer.Peer
+	// find all active peers with the same IP and disconnect them before adding to black list
+	a.active.forEach(func(_ peer.ID, pi peerInfo) {
+		if storage.IpFromIpPort(pi.peer.RemoteAddr().ToIpPort()) == ip {
+			toDisconnectActivePeers = append(toDisconnectActivePeers, pi.peer)
+		}
+	})
+	for _, v := range toDisconnectActivePeers {
+		a.disconnectUnsafe(v) // disconnect the peer before adding it to the black list
+	}
+	a.addToBlackListUnsafe(addr, blockTime, reason)
+}
+
 func (a *PeerManagerImpl) AddToBlackList(p peer.Peer, blockTime time.Time, reason string) {
 	if a.blackListDuration <= 0 {
 		return
 	}
-
-	a.Disconnect(p)
+	if p.RemoteAddr().Empty() {
+		return // no need to add empty address to black list
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
+
+	a.disconnectUnsafe(p) // disconnect the peer before adding it to the black list
+	a.addToBlackListUnsafe(p.RemoteAddr(), blockTime, reason)
+}
+
+// addToBlackListUnsafe adds the peer to the black list without acquiring the lock,
+// so it should be called only when the lock is already acquired.
+func (a *PeerManagerImpl) addToBlackListUnsafe(peerAddr proto.TCPAddr, blockTime time.Time, reason string) {
 	blackListed := storage.NewBlackListedPeer(
-		storage.IpFromIpPort(p.RemoteAddr().ToIpPort()),
+		storage.IpFromIpPort(peerAddr.ToIpPort()),
 		blockTime.UnixMilli(),
 		a.blackListDuration,
 		reason,
 	)
 	if err := a.peerStorage.AddToBlackList([]storage.BlackListedPeer{blackListed}); err != nil {
-		slog.Error("Failed to add peer to black list", slog.Any("peer", p.ID()),
+		slog.Error("Failed to add peer to black list", slog.Any("peer-addr", peerAddr),
+			slog.Duration("black-list-duration", a.blackListDuration),
 			slog.String("reason", reason), logging.Error(err))
 	} else {
-		a.logger.Debug("Peer added to black list", "peer", p.ID(), "reason", reason)
+		a.logger.Debug("Peer added to black list", slog.Any("peer-addr", peerAddr),
+			slog.Duration("black-list-duration", a.blackListDuration), slog.String("reason", reason))
 	}
 }
 
@@ -383,6 +419,12 @@ func (a *PeerManagerImpl) AskPeers() {
 func (a *PeerManagerImpl) Disconnect(p peer.Peer) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.disconnectUnsafe(p)
+}
+
+// disconnectUnsafe disconnects the peer without acquiring the lock,
+// so it should be called only when the lock is already acquired.
+func (a *PeerManagerImpl) disconnectUnsafe(p peer.Peer) {
 	pid := p.ID()
 	a.active.remove(pid)
 	if err := p.Close(); err != nil {

--- a/pkg/p2p/conn/mock_deadline_reader_test.go
+++ b/pkg/p2p/conn/mock_deadline_reader_test.go
@@ -70,7 +70,7 @@ type MockDeadlineReader_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockDeadlineReader_Expecter) Read(p interface{}) *MockDeadlineReader_Read_Call {
+func (_e *MockDeadlineReader_Expecter) Read(p any) *MockDeadlineReader_Read_Call {
 	return &MockDeadlineReader_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -121,7 +121,7 @@ type MockDeadlineReader_SetReadDeadline_Call struct {
 
 // SetReadDeadline is a helper method to define mock.On call
 //   - t time.Time
-func (_e *MockDeadlineReader_Expecter) SetReadDeadline(t interface{}) *MockDeadlineReader_SetReadDeadline_Call {
+func (_e *MockDeadlineReader_Expecter) SetReadDeadline(t any) *MockDeadlineReader_SetReadDeadline_Call {
 	return &MockDeadlineReader_SetReadDeadline_Call{Call: _e.mock.On("SetReadDeadline", t)}
 }
 

--- a/pkg/p2p/peer/mock_peer_exported.go
+++ b/pkg/p2p/peer/mock_peer_exported.go
@@ -195,7 +195,7 @@ type MockPeer_Equal_Call struct {
 
 // Equal is a helper method to define mock.On call
 //   - peer Peer
-func (_e *MockPeer_Expecter) Equal(peer interface{}) *MockPeer_Equal_Call {
+func (_e *MockPeer_Expecter) Equal(peer any) *MockPeer_Equal_Call {
 	return &MockPeer_Equal_Call{Call: _e.mock.On("Equal", peer)}
 }
 
@@ -369,7 +369,7 @@ type MockPeer_SendMessage_Call struct {
 
 // SendMessage is a helper method to define mock.On call
 //   - message proto.Message
-func (_e *MockPeer_Expecter) SendMessage(message interface{}) *MockPeer_SendMessage_Call {
+func (_e *MockPeer_Expecter) SendMessage(message any) *MockPeer_SendMessage_Call {
 	return &MockPeer_SendMessage_Call{Call: _e.mock.On("SendMessage", message)}
 }
 

--- a/pkg/ride/mock_environment_test.go
+++ b/pkg/ride/mock_environment_test.go
@@ -196,7 +196,7 @@ type MockEnvironment_checkMessageLength_Call struct {
 
 // checkMessageLength is a helper method to define mock.On call
 //   - n int
-func (_e *MockEnvironment_Expecter) checkMessageLength(n interface{}) *MockEnvironment_checkMessageLength_Call {
+func (_e *MockEnvironment_Expecter) checkMessageLength(n any) *MockEnvironment_checkMessageLength_Call {
 	return &MockEnvironment_checkMessageLength_Call{Call: _e.mock.On("checkMessageLength", n)}
 }
 
@@ -821,7 +821,7 @@ type MockEnvironment_setComplexityCalculator_Call struct {
 
 // setComplexityCalculator is a helper method to define mock.On call
 //   - cc complexityCalculator
-func (_e *MockEnvironment_Expecter) setComplexityCalculator(cc interface{}) *MockEnvironment_setComplexityCalculator_Call {
+func (_e *MockEnvironment_Expecter) setComplexityCalculator(cc any) *MockEnvironment_setComplexityCalculator_Call {
 	return &MockEnvironment_setComplexityCalculator_Call{Call: _e.mock.On("setComplexityCalculator", cc)}
 }
 
@@ -861,7 +861,7 @@ type MockEnvironment_setInvocation_Call struct {
 
 // setInvocation is a helper method to define mock.On call
 //   - inv rideType
-func (_e *MockEnvironment_Expecter) setInvocation(inv interface{}) *MockEnvironment_setInvocation_Call {
+func (_e *MockEnvironment_Expecter) setInvocation(inv any) *MockEnvironment_setInvocation_Call {
 	return &MockEnvironment_setInvocation_Call{Call: _e.mock.On("setInvocation", inv)}
 }
 
@@ -901,7 +901,7 @@ type MockEnvironment_setLibVersion_Call struct {
 
 // setLibVersion is a helper method to define mock.On call
 //   - v ast.LibraryVersion
-func (_e *MockEnvironment_Expecter) setLibVersion(v interface{}) *MockEnvironment_setLibVersion_Call {
+func (_e *MockEnvironment_Expecter) setLibVersion(v any) *MockEnvironment_setLibVersion_Call {
 	return &MockEnvironment_setLibVersion_Call{Call: _e.mock.On("setLibVersion", v)}
 }
 
@@ -941,7 +941,7 @@ type MockEnvironment_setNewDAppAddress_Call struct {
 
 // setNewDAppAddress is a helper method to define mock.On call
 //   - address proto.WavesAddress
-func (_e *MockEnvironment_Expecter) setNewDAppAddress(address interface{}) *MockEnvironment_setNewDAppAddress_Call {
+func (_e *MockEnvironment_Expecter) setNewDAppAddress(address any) *MockEnvironment_setNewDAppAddress_Call {
 	return &MockEnvironment_setNewDAppAddress_Call{Call: _e.mock.On("setNewDAppAddress", address)}
 }
 
@@ -1039,7 +1039,7 @@ type MockEnvironment_takeString_Call struct {
 // takeString is a helper method to define mock.On call
 //   - s string
 //   - n int
-func (_e *MockEnvironment_Expecter) takeString(s interface{}, n interface{}) *MockEnvironment_takeString_Call {
+func (_e *MockEnvironment_Expecter) takeString(s any, n any) *MockEnvironment_takeString_Call {
 	return &MockEnvironment_takeString_Call{Call: _e.mock.On("takeString", s, n)}
 }
 

--- a/pkg/state/mock_features_state_test.go
+++ b/pkg/state/mock_features_state_test.go
@@ -62,7 +62,7 @@ type MockFeaturesState_activateFeature_Call struct {
 //   - featureID int16
 //   - r *activatedFeaturesRecord
 //   - blockID proto.BlockID
-func (_e *MockFeaturesState_Expecter) activateFeature(featureID interface{}, r interface{}, blockID interface{}) *MockFeaturesState_activateFeature_Call {
+func (_e *MockFeaturesState_Expecter) activateFeature(featureID any, r any, blockID any) *MockFeaturesState_activateFeature_Call {
 	return &MockFeaturesState_activateFeature_Call{Call: _e.mock.On("activateFeature", featureID, r, blockID)}
 }
 
@@ -132,7 +132,7 @@ type MockFeaturesState_activationHeight_Call struct {
 
 // activationHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) activationHeight(featureID interface{}) *MockFeaturesState_activationHeight_Call {
+func (_e *MockFeaturesState_Expecter) activationHeight(featureID any) *MockFeaturesState_activationHeight_Call {
 	return &MockFeaturesState_activationHeight_Call{Call: _e.mock.On("activationHeight", featureID)}
 }
 
@@ -184,7 +184,7 @@ type MockFeaturesState_addVote_Call struct {
 // addVote is a helper method to define mock.On call
 //   - featureID int16
 //   - blockID proto.BlockID
-func (_e *MockFeaturesState_Expecter) addVote(featureID interface{}, blockID interface{}) *MockFeaturesState_addVote_Call {
+func (_e *MockFeaturesState_Expecter) addVote(featureID any, blockID any) *MockFeaturesState_addVote_Call {
 	return &MockFeaturesState_addVote_Call{Call: _e.mock.On("addVote", featureID, blockID)}
 }
 
@@ -304,7 +304,7 @@ type MockFeaturesState_approvalHeight_Call struct {
 
 // approvalHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) approvalHeight(featureID interface{}) *MockFeaturesState_approvalHeight_Call {
+func (_e *MockFeaturesState_Expecter) approvalHeight(featureID any) *MockFeaturesState_approvalHeight_Call {
 	return &MockFeaturesState_approvalHeight_Call{Call: _e.mock.On("approvalHeight", featureID)}
 }
 
@@ -357,7 +357,7 @@ type MockFeaturesState_approveFeature_Call struct {
 //   - featureID int16
 //   - r *approvedFeaturesRecord
 //   - blockID proto.BlockID
-func (_e *MockFeaturesState_Expecter) approveFeature(featureID interface{}, r interface{}, blockID interface{}) *MockFeaturesState_approveFeature_Call {
+func (_e *MockFeaturesState_Expecter) approveFeature(featureID any, r any, blockID any) *MockFeaturesState_approveFeature_Call {
 	return &MockFeaturesState_approveFeature_Call{Call: _e.mock.On("approveFeature", featureID, r, blockID)}
 }
 
@@ -460,7 +460,7 @@ type MockFeaturesState_featureVotes_Call struct {
 
 // featureVotes is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) featureVotes(featureID interface{}) *MockFeaturesState_featureVotes_Call {
+func (_e *MockFeaturesState_Expecter) featureVotes(featureID any) *MockFeaturesState_featureVotes_Call {
 	return &MockFeaturesState_featureVotes_Call{Call: _e.mock.On("featureVotes", featureID)}
 }
 
@@ -521,7 +521,7 @@ type MockFeaturesState_featureVotesAtHeight_Call struct {
 // featureVotesAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height uint64
-func (_e *MockFeaturesState_Expecter) featureVotesAtHeight(featureID interface{}, height interface{}) *MockFeaturesState_featureVotesAtHeight_Call {
+func (_e *MockFeaturesState_Expecter) featureVotesAtHeight(featureID any, height any) *MockFeaturesState_featureVotesAtHeight_Call {
 	return &MockFeaturesState_featureVotesAtHeight_Call{Call: _e.mock.On("featureVotesAtHeight", featureID, height)}
 }
 
@@ -578,7 +578,7 @@ type MockFeaturesState_finishVoting_Call struct {
 // finishVoting is a helper method to define mock.On call
 //   - curHeight uint64
 //   - blockID proto.BlockID
-func (_e *MockFeaturesState_Expecter) finishVoting(curHeight interface{}, blockID interface{}) *MockFeaturesState_finishVoting_Call {
+func (_e *MockFeaturesState_Expecter) finishVoting(curHeight any, blockID any) *MockFeaturesState_finishVoting_Call {
 	return &MockFeaturesState_finishVoting_Call{Call: _e.mock.On("finishVoting", curHeight, blockID)}
 }
 
@@ -643,7 +643,7 @@ type MockFeaturesState_isActivated_Call struct {
 
 // isActivated is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) isActivated(featureID interface{}) *MockFeaturesState_isActivated_Call {
+func (_e *MockFeaturesState_Expecter) isActivated(featureID any) *MockFeaturesState_isActivated_Call {
 	return &MockFeaturesState_isActivated_Call{Call: _e.mock.On("isActivated", featureID)}
 }
 
@@ -695,7 +695,7 @@ type MockFeaturesState_isActivatedAtHeight_Call struct {
 // isActivatedAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height uint64
-func (_e *MockFeaturesState_Expecter) isActivatedAtHeight(featureID interface{}, height interface{}) *MockFeaturesState_isActivatedAtHeight_Call {
+func (_e *MockFeaturesState_Expecter) isActivatedAtHeight(featureID any, height any) *MockFeaturesState_isActivatedAtHeight_Call {
 	return &MockFeaturesState_isActivatedAtHeight_Call{Call: _e.mock.On("isActivatedAtHeight", featureID, height)}
 }
 
@@ -760,7 +760,7 @@ type MockFeaturesState_isApproved_Call struct {
 
 // isApproved is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) isApproved(featureID interface{}) *MockFeaturesState_isApproved_Call {
+func (_e *MockFeaturesState_Expecter) isApproved(featureID any) *MockFeaturesState_isApproved_Call {
 	return &MockFeaturesState_isApproved_Call{Call: _e.mock.On("isApproved", featureID)}
 }
 
@@ -812,7 +812,7 @@ type MockFeaturesState_isApprovedAtHeight_Call struct {
 // isApprovedAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height uint64
-func (_e *MockFeaturesState_Expecter) isApprovedAtHeight(featureID interface{}, height interface{}) *MockFeaturesState_isApprovedAtHeight_Call {
+func (_e *MockFeaturesState_Expecter) isApprovedAtHeight(featureID any, height any) *MockFeaturesState_isApprovedAtHeight_Call {
 	return &MockFeaturesState_isApprovedAtHeight_Call{Call: _e.mock.On("isApprovedAtHeight", featureID, height)}
 }
 
@@ -869,7 +869,7 @@ type MockFeaturesState_minimalGeneratingBalanceAtHeight_Call struct {
 // minimalGeneratingBalanceAtHeight is a helper method to define mock.On call
 //   - v proto.Height
 //   - v1 uint64
-func (_e *MockFeaturesState_Expecter) minimalGeneratingBalanceAtHeight(v interface{}, v1 interface{}) *MockFeaturesState_minimalGeneratingBalanceAtHeight_Call {
+func (_e *MockFeaturesState_Expecter) minimalGeneratingBalanceAtHeight(v any, v1 any) *MockFeaturesState_minimalGeneratingBalanceAtHeight_Call {
 	return &MockFeaturesState_minimalGeneratingBalanceAtHeight_Call{Call: _e.mock.On("minimalGeneratingBalanceAtHeight", v, v1)}
 }
 
@@ -934,7 +934,7 @@ type MockFeaturesState_newestActivationHeight_Call struct {
 
 // newestActivationHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) newestActivationHeight(featureID interface{}) *MockFeaturesState_newestActivationHeight_Call {
+func (_e *MockFeaturesState_Expecter) newestActivationHeight(featureID any) *MockFeaturesState_newestActivationHeight_Call {
 	return &MockFeaturesState_newestActivationHeight_Call{Call: _e.mock.On("newestActivationHeight", featureID)}
 }
 
@@ -994,7 +994,7 @@ type MockFeaturesState_newestApprovalHeight_Call struct {
 
 // newestApprovalHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) newestApprovalHeight(featureID interface{}) *MockFeaturesState_newestApprovalHeight_Call {
+func (_e *MockFeaturesState_Expecter) newestApprovalHeight(featureID any) *MockFeaturesState_newestApprovalHeight_Call {
 	return &MockFeaturesState_newestApprovalHeight_Call{Call: _e.mock.On("newestApprovalHeight", featureID)}
 }
 
@@ -1054,7 +1054,7 @@ type MockFeaturesState_newestIsActivated_Call struct {
 
 // newestIsActivated is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) newestIsActivated(featureID interface{}) *MockFeaturesState_newestIsActivated_Call {
+func (_e *MockFeaturesState_Expecter) newestIsActivated(featureID any) *MockFeaturesState_newestIsActivated_Call {
 	return &MockFeaturesState_newestIsActivated_Call{Call: _e.mock.On("newestIsActivated", featureID)}
 }
 
@@ -1106,7 +1106,7 @@ type MockFeaturesState_newestIsActivatedAtHeight_Call struct {
 // newestIsActivatedAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height uint64
-func (_e *MockFeaturesState_Expecter) newestIsActivatedAtHeight(featureID interface{}, height interface{}) *MockFeaturesState_newestIsActivatedAtHeight_Call {
+func (_e *MockFeaturesState_Expecter) newestIsActivatedAtHeight(featureID any, height any) *MockFeaturesState_newestIsActivatedAtHeight_Call {
 	return &MockFeaturesState_newestIsActivatedAtHeight_Call{Call: _e.mock.On("newestIsActivatedAtHeight", featureID, height)}
 }
 
@@ -1172,7 +1172,7 @@ type MockFeaturesState_newestIsActivatedForNBlocks_Call struct {
 // newestIsActivatedForNBlocks is a helper method to define mock.On call
 //   - featureID int16
 //   - n int
-func (_e *MockFeaturesState_Expecter) newestIsActivatedForNBlocks(featureID interface{}, n interface{}) *MockFeaturesState_newestIsActivatedForNBlocks_Call {
+func (_e *MockFeaturesState_Expecter) newestIsActivatedForNBlocks(featureID any, n any) *MockFeaturesState_newestIsActivatedForNBlocks_Call {
 	return &MockFeaturesState_newestIsActivatedForNBlocks_Call{Call: _e.mock.On("newestIsActivatedForNBlocks", featureID, n)}
 }
 
@@ -1237,7 +1237,7 @@ type MockFeaturesState_newestIsApproved_Call struct {
 
 // newestIsApproved is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockFeaturesState_Expecter) newestIsApproved(featureID interface{}) *MockFeaturesState_newestIsApproved_Call {
+func (_e *MockFeaturesState_Expecter) newestIsApproved(featureID any) *MockFeaturesState_newestIsApproved_Call {
 	return &MockFeaturesState_newestIsApproved_Call{Call: _e.mock.On("newestIsApproved", featureID)}
 }
 
@@ -1288,7 +1288,7 @@ type MockFeaturesState_resetVotes_Call struct {
 
 // resetVotes is a helper method to define mock.On call
 //   - blockID proto.BlockID
-func (_e *MockFeaturesState_Expecter) resetVotes(blockID interface{}) *MockFeaturesState_resetVotes_Call {
+func (_e *MockFeaturesState_Expecter) resetVotes(blockID any) *MockFeaturesState_resetVotes_Call {
 	return &MockFeaturesState_resetVotes_Call{Call: _e.mock.On("resetVotes", blockID)}
 }
 

--- a/pkg/state/mock_script_storage_state_test.go
+++ b/pkg/state/mock_script_storage_state_test.go
@@ -71,7 +71,7 @@ type MockScriptStorageState_accountHasScript_Call struct {
 
 // accountHasScript is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) accountHasScript(addr interface{}) *MockScriptStorageState_accountHasScript_Call {
+func (_e *MockScriptStorageState_Expecter) accountHasScript(addr any) *MockScriptStorageState_accountHasScript_Call {
 	return &MockScriptStorageState_accountHasScript_Call{Call: _e.mock.On("accountHasScript", addr)}
 }
 
@@ -131,7 +131,7 @@ type MockScriptStorageState_accountHasVerifier_Call struct {
 
 // accountHasVerifier is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) accountHasVerifier(addr interface{}) *MockScriptStorageState_accountHasVerifier_Call {
+func (_e *MockScriptStorageState_Expecter) accountHasVerifier(addr any) *MockScriptStorageState_accountHasVerifier_Call {
 	return &MockScriptStorageState_accountHasVerifier_Call{Call: _e.mock.On("accountHasVerifier", addr)}
 }
 
@@ -191,7 +191,7 @@ type MockScriptStorageState_accountIsDApp_Call struct {
 
 // accountIsDApp is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) accountIsDApp(addr interface{}) *MockScriptStorageState_accountIsDApp_Call {
+func (_e *MockScriptStorageState_Expecter) accountIsDApp(addr any) *MockScriptStorageState_accountIsDApp_Call {
 	return &MockScriptStorageState_accountIsDApp_Call{Call: _e.mock.On("accountIsDApp", addr)}
 }
 
@@ -286,7 +286,7 @@ type MockScriptStorageState_commitUncertain_Call struct {
 
 // commitUncertain is a helper method to define mock.On call
 //   - blockID proto.BlockID
-func (_e *MockScriptStorageState_Expecter) commitUncertain(blockID interface{}) *MockScriptStorageState_commitUncertain_Call {
+func (_e *MockScriptStorageState_Expecter) commitUncertain(blockID any) *MockScriptStorageState_commitUncertain_Call {
 	return &MockScriptStorageState_commitUncertain_Call{Call: _e.mock.On("commitUncertain", blockID)}
 }
 
@@ -471,7 +471,7 @@ type MockScriptStorageState_isSmartAsset_Call struct {
 
 // isSmartAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) isSmartAsset(assetID interface{}) *MockScriptStorageState_isSmartAsset_Call {
+func (_e *MockScriptStorageState_Expecter) isSmartAsset(assetID any) *MockScriptStorageState_isSmartAsset_Call {
 	return &MockScriptStorageState_isSmartAsset_Call{Call: _e.mock.On("isSmartAsset", assetID)}
 }
 
@@ -531,7 +531,7 @@ type MockScriptStorageState_newestAccountHasScript_Call struct {
 
 // newestAccountHasScript is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) newestAccountHasScript(addr interface{}) *MockScriptStorageState_newestAccountHasScript_Call {
+func (_e *MockScriptStorageState_Expecter) newestAccountHasScript(addr any) *MockScriptStorageState_newestAccountHasScript_Call {
 	return &MockScriptStorageState_newestAccountHasScript_Call{Call: _e.mock.On("newestAccountHasScript", addr)}
 }
 
@@ -591,7 +591,7 @@ type MockScriptStorageState_newestAccountHasVerifier_Call struct {
 
 // newestAccountHasVerifier is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) newestAccountHasVerifier(addr interface{}) *MockScriptStorageState_newestAccountHasVerifier_Call {
+func (_e *MockScriptStorageState_Expecter) newestAccountHasVerifier(addr any) *MockScriptStorageState_newestAccountHasVerifier_Call {
 	return &MockScriptStorageState_newestAccountHasVerifier_Call{Call: _e.mock.On("newestAccountHasVerifier", addr)}
 }
 
@@ -651,7 +651,7 @@ type MockScriptStorageState_newestAccountIsDApp_Call struct {
 
 // newestAccountIsDApp is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) newestAccountIsDApp(addr interface{}) *MockScriptStorageState_newestAccountIsDApp_Call {
+func (_e *MockScriptStorageState_Expecter) newestAccountIsDApp(addr any) *MockScriptStorageState_newestAccountIsDApp_Call {
 	return &MockScriptStorageState_newestAccountIsDApp_Call{Call: _e.mock.On("newestAccountIsDApp", addr)}
 }
 
@@ -711,7 +711,7 @@ type MockScriptStorageState_newestIsSmartAsset_Call struct {
 
 // newestIsSmartAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) newestIsSmartAsset(assetID interface{}) *MockScriptStorageState_newestIsSmartAsset_Call {
+func (_e *MockScriptStorageState_Expecter) newestIsSmartAsset(assetID any) *MockScriptStorageState_newestIsSmartAsset_Call {
 	return &MockScriptStorageState_newestIsSmartAsset_Call{Call: _e.mock.On("newestIsSmartAsset", assetID)}
 }
 
@@ -771,7 +771,7 @@ type MockScriptStorageState_newestScriptBasicInfoByAddressID_Call struct {
 
 // newestScriptBasicInfoByAddressID is a helper method to define mock.On call
 //   - addressID proto.AddressID
-func (_e *MockScriptStorageState_Expecter) newestScriptBasicInfoByAddressID(addressID interface{}) *MockScriptStorageState_newestScriptBasicInfoByAddressID_Call {
+func (_e *MockScriptStorageState_Expecter) newestScriptBasicInfoByAddressID(addressID any) *MockScriptStorageState_newestScriptBasicInfoByAddressID_Call {
 	return &MockScriptStorageState_newestScriptBasicInfoByAddressID_Call{Call: _e.mock.On("newestScriptBasicInfoByAddressID", addressID)}
 }
 
@@ -833,7 +833,7 @@ type MockScriptStorageState_newestScriptByAddr_Call struct {
 
 // newestScriptByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) newestScriptByAddr(addr interface{}) *MockScriptStorageState_newestScriptByAddr_Call {
+func (_e *MockScriptStorageState_Expecter) newestScriptByAddr(addr any) *MockScriptStorageState_newestScriptByAddr_Call {
 	return &MockScriptStorageState_newestScriptByAddr_Call{Call: _e.mock.On("newestScriptByAddr", addr)}
 }
 
@@ -895,7 +895,7 @@ type MockScriptStorageState_newestScriptByAsset_Call struct {
 
 // newestScriptByAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) newestScriptByAsset(assetID interface{}) *MockScriptStorageState_newestScriptByAsset_Call {
+func (_e *MockScriptStorageState_Expecter) newestScriptByAsset(assetID any) *MockScriptStorageState_newestScriptByAsset_Call {
 	return &MockScriptStorageState_newestScriptByAsset_Call{Call: _e.mock.On("newestScriptByAsset", assetID)}
 }
 
@@ -957,7 +957,7 @@ type MockScriptStorageState_newestScriptBytesByAddr_Call struct {
 
 // newestScriptBytesByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) newestScriptBytesByAddr(addr interface{}) *MockScriptStorageState_newestScriptBytesByAddr_Call {
+func (_e *MockScriptStorageState_Expecter) newestScriptBytesByAddr(addr any) *MockScriptStorageState_newestScriptBytesByAddr_Call {
 	return &MockScriptStorageState_newestScriptBytesByAddr_Call{Call: _e.mock.On("newestScriptBytesByAddr", addr)}
 }
 
@@ -1019,7 +1019,7 @@ type MockScriptStorageState_newestScriptBytesByAsset_Call struct {
 
 // newestScriptBytesByAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) newestScriptBytesByAsset(assetID interface{}) *MockScriptStorageState_newestScriptBytesByAsset_Call {
+func (_e *MockScriptStorageState_Expecter) newestScriptBytesByAsset(assetID any) *MockScriptStorageState_newestScriptBytesByAsset_Call {
 	return &MockScriptStorageState_newestScriptBytesByAsset_Call{Call: _e.mock.On("newestScriptBytesByAsset", assetID)}
 }
 
@@ -1156,7 +1156,7 @@ type MockScriptStorageState_scriptBasicInfoByAddressID_Call struct {
 
 // scriptBasicInfoByAddressID is a helper method to define mock.On call
 //   - addressID proto.AddressID
-func (_e *MockScriptStorageState_Expecter) scriptBasicInfoByAddressID(addressID interface{}) *MockScriptStorageState_scriptBasicInfoByAddressID_Call {
+func (_e *MockScriptStorageState_Expecter) scriptBasicInfoByAddressID(addressID any) *MockScriptStorageState_scriptBasicInfoByAddressID_Call {
 	return &MockScriptStorageState_scriptBasicInfoByAddressID_Call{Call: _e.mock.On("scriptBasicInfoByAddressID", addressID)}
 }
 
@@ -1218,7 +1218,7 @@ type MockScriptStorageState_scriptByAddr_Call struct {
 
 // scriptByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) scriptByAddr(addr interface{}) *MockScriptStorageState_scriptByAddr_Call {
+func (_e *MockScriptStorageState_Expecter) scriptByAddr(addr any) *MockScriptStorageState_scriptByAddr_Call {
 	return &MockScriptStorageState_scriptByAddr_Call{Call: _e.mock.On("scriptByAddr", addr)}
 }
 
@@ -1280,7 +1280,7 @@ type MockScriptStorageState_scriptByAsset_Call struct {
 
 // scriptByAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) scriptByAsset(assetID interface{}) *MockScriptStorageState_scriptByAsset_Call {
+func (_e *MockScriptStorageState_Expecter) scriptByAsset(assetID any) *MockScriptStorageState_scriptByAsset_Call {
 	return &MockScriptStorageState_scriptByAsset_Call{Call: _e.mock.On("scriptByAsset", assetID)}
 }
 
@@ -1342,7 +1342,7 @@ type MockScriptStorageState_scriptBytesByAddr_Call struct {
 
 // scriptBytesByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockScriptStorageState_Expecter) scriptBytesByAddr(addr interface{}) *MockScriptStorageState_scriptBytesByAddr_Call {
+func (_e *MockScriptStorageState_Expecter) scriptBytesByAddr(addr any) *MockScriptStorageState_scriptBytesByAddr_Call {
 	return &MockScriptStorageState_scriptBytesByAddr_Call{Call: _e.mock.On("scriptBytesByAddr", addr)}
 }
 
@@ -1404,7 +1404,7 @@ type MockScriptStorageState_scriptBytesByAsset_Call struct {
 
 // scriptBytesByAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockScriptStorageState_Expecter) scriptBytesByAsset(assetID interface{}) *MockScriptStorageState_scriptBytesByAsset_Call {
+func (_e *MockScriptStorageState_Expecter) scriptBytesByAsset(assetID any) *MockScriptStorageState_scriptBytesByAsset_Call {
 	return &MockScriptStorageState_scriptBytesByAsset_Call{Call: _e.mock.On("scriptBytesByAsset", assetID)}
 }
 
@@ -1458,7 +1458,7 @@ type MockScriptStorageState_setAccountScript_Call struct {
 //   - script proto.Script
 //   - pk crypto.PublicKey
 //   - blockID proto.BlockID
-func (_e *MockScriptStorageState_Expecter) setAccountScript(addr interface{}, script interface{}, pk interface{}, blockID interface{}) *MockScriptStorageState_setAccountScript_Call {
+func (_e *MockScriptStorageState_Expecter) setAccountScript(addr any, script any, pk any, blockID any) *MockScriptStorageState_setAccountScript_Call {
 	return &MockScriptStorageState_setAccountScript_Call{Call: _e.mock.On("setAccountScript", addr, script, pk, blockID)}
 }
 
@@ -1526,7 +1526,7 @@ type MockScriptStorageState_setAssetScript_Call struct {
 //   - assetID crypto.Digest
 //   - script proto.Script
 //   - blockID proto.BlockID
-func (_e *MockScriptStorageState_Expecter) setAssetScript(assetID interface{}, script interface{}, blockID interface{}) *MockScriptStorageState_setAssetScript_Call {
+func (_e *MockScriptStorageState_Expecter) setAssetScript(assetID any, script any, blockID any) *MockScriptStorageState_setAssetScript_Call {
 	return &MockScriptStorageState_setAssetScript_Call{Call: _e.mock.On("setAssetScript", assetID, script, blockID)}
 }
 
@@ -1589,7 +1589,7 @@ type MockScriptStorageState_setAssetScriptUncertain_Call struct {
 //   - fullAssetID crypto.Digest
 //   - script proto.Script
 //   - pk crypto.PublicKey
-func (_e *MockScriptStorageState_Expecter) setAssetScriptUncertain(fullAssetID interface{}, script interface{}, pk interface{}) *MockScriptStorageState_setAssetScriptUncertain_Call {
+func (_e *MockScriptStorageState_Expecter) setAssetScriptUncertain(fullAssetID any, script any, pk any) *MockScriptStorageState_setAssetScriptUncertain_Call {
 	return &MockScriptStorageState_setAssetScriptUncertain_Call{Call: _e.mock.On("setAssetScriptUncertain", fullAssetID, script, pk)}
 }
 

--- a/pkg/state/mock_state.go
+++ b/pkg/state/mock_state.go
@@ -74,7 +74,7 @@ type MockState_ActivationHeight_Call struct {
 
 // ActivationHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockState_Expecter) ActivationHeight(featureID interface{}) *MockState_ActivationHeight_Call {
+func (_e *MockState_Expecter) ActivationHeight(featureID any) *MockState_ActivationHeight_Call {
 	return &MockState_ActivationHeight_Call{Call: _e.mock.On("ActivationHeight", featureID)}
 }
 
@@ -136,7 +136,7 @@ type MockState_AddBlock_Call struct {
 
 // AddBlock is a helper method to define mock.On call
 //   - block []byte
-func (_e *MockState_Expecter) AddBlock(block interface{}) *MockState_AddBlock_Call {
+func (_e *MockState_Expecter) AddBlock(block any) *MockState_AddBlock_Call {
 	return &MockState_AddBlock_Call{Call: _e.mock.On("AddBlock", block)}
 }
 
@@ -187,7 +187,7 @@ type MockState_AddBlocks_Call struct {
 
 // AddBlocks is a helper method to define mock.On call
 //   - blocks [][]byte
-func (_e *MockState_Expecter) AddBlocks(blocks interface{}) *MockState_AddBlocks_Call {
+func (_e *MockState_Expecter) AddBlocks(blocks any) *MockState_AddBlocks_Call {
 	return &MockState_AddBlocks_Call{Call: _e.mock.On("AddBlocks", blocks)}
 }
 
@@ -239,7 +239,7 @@ type MockState_AddBlocksWithSnapshots_Call struct {
 // AddBlocksWithSnapshots is a helper method to define mock.On call
 //   - blocks [][]byte
 //   - snapshots []*proto.BlockSnapshot
-func (_e *MockState_Expecter) AddBlocksWithSnapshots(blocks interface{}, snapshots interface{}) *MockState_AddBlocksWithSnapshots_Call {
+func (_e *MockState_Expecter) AddBlocksWithSnapshots(blocks any, snapshots any) *MockState_AddBlocksWithSnapshots_Call {
 	return &MockState_AddBlocksWithSnapshots_Call{Call: _e.mock.On("AddBlocksWithSnapshots", blocks, snapshots)}
 }
 
@@ -306,7 +306,7 @@ type MockState_AddDeserializedBlock_Call struct {
 
 // AddDeserializedBlock is a helper method to define mock.On call
 //   - block *proto.Block
-func (_e *MockState_Expecter) AddDeserializedBlock(block interface{}) *MockState_AddDeserializedBlock_Call {
+func (_e *MockState_Expecter) AddDeserializedBlock(block any) *MockState_AddDeserializedBlock_Call {
 	return &MockState_AddDeserializedBlock_Call{Call: _e.mock.On("AddDeserializedBlock", block)}
 }
 
@@ -368,7 +368,7 @@ type MockState_AddDeserializedBlocks_Call struct {
 
 // AddDeserializedBlocks is a helper method to define mock.On call
 //   - blocks []*proto.Block
-func (_e *MockState_Expecter) AddDeserializedBlocks(blocks interface{}) *MockState_AddDeserializedBlocks_Call {
+func (_e *MockState_Expecter) AddDeserializedBlocks(blocks any) *MockState_AddDeserializedBlocks_Call {
 	return &MockState_AddDeserializedBlocks_Call{Call: _e.mock.On("AddDeserializedBlocks", blocks)}
 }
 
@@ -431,7 +431,7 @@ type MockState_AddDeserializedBlocksWithSnapshots_Call struct {
 // AddDeserializedBlocksWithSnapshots is a helper method to define mock.On call
 //   - blocks []*proto.Block
 //   - snapshots []*proto.BlockSnapshot
-func (_e *MockState_Expecter) AddDeserializedBlocksWithSnapshots(blocks interface{}, snapshots interface{}) *MockState_AddDeserializedBlocksWithSnapshots_Call {
+func (_e *MockState_Expecter) AddDeserializedBlocksWithSnapshots(blocks any, snapshots any) *MockState_AddDeserializedBlocksWithSnapshots_Call {
 	return &MockState_AddDeserializedBlocksWithSnapshots_Call{Call: _e.mock.On("AddDeserializedBlocksWithSnapshots", blocks, snapshots)}
 }
 
@@ -498,7 +498,7 @@ type MockState_AddrByAlias_Call struct {
 
 // AddrByAlias is a helper method to define mock.On call
 //   - alias proto.Alias
-func (_e *MockState_Expecter) AddrByAlias(alias interface{}) *MockState_AddrByAlias_Call {
+func (_e *MockState_Expecter) AddrByAlias(alias any) *MockState_AddrByAlias_Call {
 	return &MockState_AddrByAlias_Call{Call: _e.mock.On("AddrByAlias", alias)}
 }
 
@@ -560,7 +560,7 @@ type MockState_AliasesByAddr_Call struct {
 
 // AliasesByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockState_Expecter) AliasesByAddr(addr interface{}) *MockState_AliasesByAddr_Call {
+func (_e *MockState_Expecter) AliasesByAddr(addr any) *MockState_AliasesByAddr_Call {
 	return &MockState_AliasesByAddr_Call{Call: _e.mock.On("AliasesByAddr", addr)}
 }
 
@@ -675,7 +675,7 @@ type MockState_ApprovalHeight_Call struct {
 
 // ApprovalHeight is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockState_Expecter) ApprovalHeight(featureID interface{}) *MockState_ApprovalHeight_Call {
+func (_e *MockState_Expecter) ApprovalHeight(featureID any) *MockState_ApprovalHeight_Call {
 	return &MockState_ApprovalHeight_Call{Call: _e.mock.On("ApprovalHeight", featureID)}
 }
 
@@ -736,7 +736,7 @@ type MockState_AssetBalance_Call struct {
 // AssetBalance is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) AssetBalance(account interface{}, assetID interface{}) *MockState_AssetBalance_Call {
+func (_e *MockState_Expecter) AssetBalance(account any, assetID any) *MockState_AssetBalance_Call {
 	return &MockState_AssetBalance_Call{Call: _e.mock.On("AssetBalance", account, assetID)}
 }
 
@@ -803,7 +803,7 @@ type MockState_AssetInfo_Call struct {
 
 // AssetInfo is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) AssetInfo(assetID interface{}) *MockState_AssetInfo_Call {
+func (_e *MockState_Expecter) AssetInfo(assetID any) *MockState_AssetInfo_Call {
 	return &MockState_AssetInfo_Call{Call: _e.mock.On("AssetInfo", assetID)}
 }
 
@@ -863,7 +863,7 @@ type MockState_AssetIsSponsored_Call struct {
 
 // AssetIsSponsored is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) AssetIsSponsored(assetID interface{}) *MockState_AssetIsSponsored_Call {
+func (_e *MockState_Expecter) AssetIsSponsored(assetID any) *MockState_AssetIsSponsored_Call {
 	return &MockState_AssetIsSponsored_Call{Call: _e.mock.On("AssetIsSponsored", assetID)}
 }
 
@@ -925,7 +925,7 @@ type MockState_Block_Call struct {
 
 // Block is a helper method to define mock.On call
 //   - blockID proto.BlockID
-func (_e *MockState_Expecter) Block(blockID interface{}) *MockState_Block_Call {
+func (_e *MockState_Expecter) Block(blockID any) *MockState_Block_Call {
 	return &MockState_Block_Call{Call: _e.mock.On("Block", blockID)}
 }
 
@@ -987,7 +987,7 @@ type MockState_BlockByHeight_Call struct {
 
 // BlockByHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) BlockByHeight(height interface{}) *MockState_BlockByHeight_Call {
+func (_e *MockState_Expecter) BlockByHeight(height any) *MockState_BlockByHeight_Call {
 	return &MockState_BlockByHeight_Call{Call: _e.mock.On("BlockByHeight", height)}
 }
 
@@ -1047,7 +1047,7 @@ type MockState_BlockIDToHeight_Call struct {
 
 // BlockIDToHeight is a helper method to define mock.On call
 //   - blockID proto.BlockID
-func (_e *MockState_Expecter) BlockIDToHeight(blockID interface{}) *MockState_BlockIDToHeight_Call {
+func (_e *MockState_Expecter) BlockIDToHeight(blockID any) *MockState_BlockIDToHeight_Call {
 	return &MockState_BlockIDToHeight_Call{Call: _e.mock.On("BlockIDToHeight", blockID)}
 }
 
@@ -1110,7 +1110,7 @@ type MockState_BlockRewards_Call struct {
 // BlockRewards is a helper method to define mock.On call
 //   - generator proto.WavesAddress
 //   - height proto.Height
-func (_e *MockState_Expecter) BlockRewards(generator interface{}, height interface{}) *MockState_BlockRewards_Call {
+func (_e *MockState_Expecter) BlockRewards(generator any, height any) *MockState_BlockRewards_Call {
 	return &MockState_BlockRewards_Call{Call: _e.mock.On("BlockRewards", generator, height)}
 }
 
@@ -1178,7 +1178,7 @@ type MockState_BlockVRF_Call struct {
 // BlockVRF is a helper method to define mock.On call
 //   - blockHeader *proto.BlockHeader
 //   - blockHeight proto.Height
-func (_e *MockState_Expecter) BlockVRF(blockHeader interface{}, blockHeight interface{}) *MockState_BlockVRF_Call {
+func (_e *MockState_Expecter) BlockVRF(blockHeader any, blockHeight any) *MockState_BlockVRF_Call {
 	return &MockState_BlockVRF_Call{Call: _e.mock.On("BlockVRF", blockHeader, blockHeight)}
 }
 
@@ -1299,7 +1299,7 @@ type MockState_BuildLocalEndorsementMessage_Call struct {
 // BuildLocalEndorsementMessage is a helper method to define mock.On call
 //   - v proto.Height
 //   - blockID proto.BlockID
-func (_e *MockState_Expecter) BuildLocalEndorsementMessage(v interface{}, blockID interface{}) *MockState_BuildLocalEndorsementMessage_Call {
+func (_e *MockState_Expecter) BuildLocalEndorsementMessage(v any, blockID any) *MockState_BuildLocalEndorsementMessage_Call {
 	return &MockState_BuildLocalEndorsementMessage_Call{Call: _e.mock.On("BuildLocalEndorsementMessage", v, blockID)}
 }
 
@@ -1355,7 +1355,7 @@ type MockState_CheckRollbackHeightAuto_Call struct {
 
 // CheckRollbackHeightAuto is a helper method to define mock.On call
 //   - v proto.Height
-func (_e *MockState_Expecter) CheckRollbackHeightAuto(v interface{}) *MockState_CheckRollbackHeightAuto_Call {
+func (_e *MockState_Expecter) CheckRollbackHeightAuto(v any) *MockState_CheckRollbackHeightAuto_Call {
 	return &MockState_CheckRollbackHeightAuto_Call{Call: _e.mock.On("CheckRollbackHeightAuto", v)}
 }
 
@@ -1461,7 +1461,7 @@ type MockState_CommittedGenerators_Call struct {
 
 // CommittedGenerators is a helper method to define mock.On call
 //   - v proto.Height
-func (_e *MockState_Expecter) CommittedGenerators(v interface{}) *MockState_CommittedGenerators_Call {
+func (_e *MockState_Expecter) CommittedGenerators(v any) *MockState_CommittedGenerators_Call {
 	return &MockState_CommittedGenerators_Call{Call: _e.mock.On("CommittedGenerators", v)}
 }
 
@@ -1523,7 +1523,7 @@ type MockState_CreateNextSnapshotHash_Call struct {
 
 // CreateNextSnapshotHash is a helper method to define mock.On call
 //   - block *proto.Block
-func (_e *MockState_Expecter) CreateNextSnapshotHash(block interface{}) *MockState_CreateNextSnapshotHash_Call {
+func (_e *MockState_Expecter) CreateNextSnapshotHash(block any) *MockState_CreateNextSnapshotHash_Call {
 	return &MockState_CreateNextSnapshotHash_Call{Call: _e.mock.On("CreateNextSnapshotHash", block)}
 }
 
@@ -1640,7 +1640,7 @@ type MockState_EnrichedFullAssetInfo_Call struct {
 
 // EnrichedFullAssetInfo is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) EnrichedFullAssetInfo(assetID interface{}) *MockState_EnrichedFullAssetInfo_Call {
+func (_e *MockState_Expecter) EnrichedFullAssetInfo(assetID any) *MockState_EnrichedFullAssetInfo_Call {
 	return &MockState_EnrichedFullAssetInfo_Call{Call: _e.mock.On("EnrichedFullAssetInfo", assetID)}
 }
 
@@ -1754,7 +1754,7 @@ type MockState_FindGenerator_Call struct {
 // FindGenerator is a helper method to define mock.On call
 //   - v proto.Height
 //   - fn func(GeneratorInfo) bool
-func (_e *MockState_Expecter) FindGenerator(v interface{}, fn interface{}) *MockState_FindGenerator_Call {
+func (_e *MockState_Expecter) FindGenerator(v any, fn any) *MockState_FindGenerator_Call {
 	return &MockState_FindGenerator_Call{Call: _e.mock.On("FindGenerator", v, fn)}
 }
 
@@ -1821,7 +1821,7 @@ type MockState_FullAssetInfo_Call struct {
 
 // FullAssetInfo is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) FullAssetInfo(assetID interface{}) *MockState_FullAssetInfo_Call {
+func (_e *MockState_Expecter) FullAssetInfo(assetID any) *MockState_FullAssetInfo_Call {
 	return &MockState_FullAssetInfo_Call{Call: _e.mock.On("FullAssetInfo", assetID)}
 }
 
@@ -1883,7 +1883,7 @@ type MockState_FullWavesBalance_Call struct {
 
 // FullWavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) FullWavesBalance(account interface{}) *MockState_FullWavesBalance_Call {
+func (_e *MockState_Expecter) FullWavesBalance(account any) *MockState_FullWavesBalance_Call {
 	return &MockState_FullWavesBalance_Call{Call: _e.mock.On("FullWavesBalance", account)}
 }
 
@@ -1944,7 +1944,7 @@ type MockState_GeneratingBalance_Call struct {
 // GeneratingBalance is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - height proto.Height
-func (_e *MockState_Expecter) GeneratingBalance(account interface{}, height interface{}) *MockState_GeneratingBalance_Call {
+func (_e *MockState_Expecter) GeneratingBalance(account any, height any) *MockState_GeneratingBalance_Call {
 	return &MockState_GeneratingBalance_Call{Call: _e.mock.On("GeneratingBalance", account, height)}
 }
 
@@ -2011,7 +2011,7 @@ type MockState_Header_Call struct {
 
 // Header is a helper method to define mock.On call
 //   - blockID proto.BlockID
-func (_e *MockState_Expecter) Header(blockID interface{}) *MockState_Header_Call {
+func (_e *MockState_Expecter) Header(blockID any) *MockState_Header_Call {
 	return &MockState_Header_Call{Call: _e.mock.On("Header", blockID)}
 }
 
@@ -2073,7 +2073,7 @@ type MockState_HeaderByHeight_Call struct {
 
 // HeaderByHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) HeaderByHeight(height interface{}) *MockState_HeaderByHeight_Call {
+func (_e *MockState_Expecter) HeaderByHeight(height any) *MockState_HeaderByHeight_Call {
 	return &MockState_HeaderByHeight_Call{Call: _e.mock.On("HeaderByHeight", height)}
 }
 
@@ -2186,7 +2186,7 @@ type MockState_HeightToBlockID_Call struct {
 
 // HeightToBlockID is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) HeightToBlockID(height interface{}) *MockState_HeightToBlockID_Call {
+func (_e *MockState_Expecter) HeightToBlockID(height any) *MockState_HeightToBlockID_Call {
 	return &MockState_HeightToBlockID_Call{Call: _e.mock.On("HeightToBlockID", height)}
 }
 
@@ -2248,7 +2248,7 @@ type MockState_HitSourceAtHeight_Call struct {
 
 // HitSourceAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) HitSourceAtHeight(height interface{}) *MockState_HitSourceAtHeight_Call {
+func (_e *MockState_Expecter) HitSourceAtHeight(height any) *MockState_HitSourceAtHeight_Call {
 	return &MockState_HitSourceAtHeight_Call{Call: _e.mock.On("HitSourceAtHeight", height)}
 }
 
@@ -2310,7 +2310,7 @@ type MockState_InvokeResultByID_Call struct {
 
 // InvokeResultByID is a helper method to define mock.On call
 //   - invokeID crypto.Digest
-func (_e *MockState_Expecter) InvokeResultByID(invokeID interface{}) *MockState_InvokeResultByID_Call {
+func (_e *MockState_Expecter) InvokeResultByID(invokeID any) *MockState_InvokeResultByID_Call {
 	return &MockState_InvokeResultByID_Call{Call: _e.mock.On("InvokeResultByID", invokeID)}
 }
 
@@ -2370,7 +2370,7 @@ type MockState_IsActivated_Call struct {
 
 // IsActivated is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockState_Expecter) IsActivated(featureID interface{}) *MockState_IsActivated_Call {
+func (_e *MockState_Expecter) IsActivated(featureID any) *MockState_IsActivated_Call {
 	return &MockState_IsActivated_Call{Call: _e.mock.On("IsActivated", featureID)}
 }
 
@@ -2431,7 +2431,7 @@ type MockState_IsActiveAtHeight_Call struct {
 // IsActiveAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height proto.Height
-func (_e *MockState_Expecter) IsActiveAtHeight(featureID interface{}, height interface{}) *MockState_IsActiveAtHeight_Call {
+func (_e *MockState_Expecter) IsActiveAtHeight(featureID any, height any) *MockState_IsActiveAtHeight_Call {
 	return &MockState_IsActiveAtHeight_Call{Call: _e.mock.On("IsActiveAtHeight", featureID, height)}
 }
 
@@ -2496,7 +2496,7 @@ type MockState_IsActiveLeasing_Call struct {
 
 // IsActiveLeasing is a helper method to define mock.On call
 //   - leaseID crypto.Digest
-func (_e *MockState_Expecter) IsActiveLeasing(leaseID interface{}) *MockState_IsActiveLeasing_Call {
+func (_e *MockState_Expecter) IsActiveLeasing(leaseID any) *MockState_IsActiveLeasing_Call {
 	return &MockState_IsActiveLeasing_Call{Call: _e.mock.On("IsActiveLeasing", leaseID)}
 }
 
@@ -2556,7 +2556,7 @@ type MockState_IsActiveLightNodeNewBlocksFields_Call struct {
 
 // IsActiveLightNodeNewBlocksFields is a helper method to define mock.On call
 //   - blockHeight proto.Height
-func (_e *MockState_Expecter) IsActiveLightNodeNewBlocksFields(blockHeight interface{}) *MockState_IsActiveLightNodeNewBlocksFields_Call {
+func (_e *MockState_Expecter) IsActiveLightNodeNewBlocksFields(blockHeight any) *MockState_IsActiveLightNodeNewBlocksFields_Call {
 	return &MockState_IsActiveLightNodeNewBlocksFields_Call{Call: _e.mock.On("IsActiveLightNodeNewBlocksFields", blockHeight)}
 }
 
@@ -2616,7 +2616,7 @@ type MockState_IsApproved_Call struct {
 
 // IsApproved is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockState_Expecter) IsApproved(featureID interface{}) *MockState_IsApproved_Call {
+func (_e *MockState_Expecter) IsApproved(featureID any) *MockState_IsApproved_Call {
 	return &MockState_IsApproved_Call{Call: _e.mock.On("IsApproved", featureID)}
 }
 
@@ -2677,7 +2677,7 @@ type MockState_IsApprovedAtHeight_Call struct {
 // IsApprovedAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height proto.Height
-func (_e *MockState_Expecter) IsApprovedAtHeight(featureID interface{}, height interface{}) *MockState_IsApprovedAtHeight_Call {
+func (_e *MockState_Expecter) IsApprovedAtHeight(featureID any, height any) *MockState_IsApprovedAtHeight_Call {
 	return &MockState_IsApprovedAtHeight_Call{Call: _e.mock.On("IsApprovedAtHeight", featureID, height)}
 }
 
@@ -2742,7 +2742,7 @@ type MockState_IsAssetExist_Call struct {
 
 // IsAssetExist is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) IsAssetExist(assetID interface{}) *MockState_IsAssetExist_Call {
+func (_e *MockState_Expecter) IsAssetExist(assetID any) *MockState_IsAssetExist_Call {
 	return &MockState_IsAssetExist_Call{Call: _e.mock.On("IsAssetExist", assetID)}
 }
 
@@ -2912,7 +2912,7 @@ type MockState_LegacyStateHashAtHeight_Call struct {
 
 // LegacyStateHashAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) LegacyStateHashAtHeight(height interface{}) *MockState_LegacyStateHashAtHeight_Call {
+func (_e *MockState_Expecter) LegacyStateHashAtHeight(height any) *MockState_LegacyStateHashAtHeight_Call {
 	return &MockState_LegacyStateHashAtHeight_Call{Call: _e.mock.On("LegacyStateHashAtHeight", height)}
 }
 
@@ -2963,7 +2963,7 @@ type MockState_Map_Call struct {
 
 // Map is a helper method to define mock.On call
 //   - fn func(state NonThreadSafeState) error
-func (_e *MockState_Expecter) Map(fn interface{}) *MockState_Map_Call {
+func (_e *MockState_Expecter) Map(fn any) *MockState_Map_Call {
 	return &MockState_Map_Call{Call: _e.mock.On("Map", fn)}
 }
 
@@ -3025,7 +3025,7 @@ type MockState_MapR_Call struct {
 
 // MapR is a helper method to define mock.On call
 //   - fn func(StateInfo) (any, error)
-func (_e *MockState_Expecter) MapR(fn interface{}) *MockState_MapR_Call {
+func (_e *MockState_Expecter) MapR(fn any) *MockState_MapR_Call {
 	return &MockState_MapR_Call{Call: _e.mock.On("MapR", fn)}
 }
 
@@ -3076,7 +3076,7 @@ type MockState_MapUnsafe_Call struct {
 
 // MapUnsafe is a helper method to define mock.On call
 //   - fn func(state NonThreadSafeState) error
-func (_e *MockState_Expecter) MapUnsafe(fn interface{}) *MockState_MapUnsafe_Call {
+func (_e *MockState_Expecter) MapUnsafe(fn any) *MockState_MapUnsafe_Call {
 	return &MockState_MapUnsafe_Call{Call: _e.mock.On("MapUnsafe", fn)}
 }
 
@@ -3140,7 +3140,7 @@ type MockState_NFTList_Call struct {
 //   - account proto.Recipient
 //   - limit uint64
 //   - afterAssetID *proto.AssetID
-func (_e *MockState_Expecter) NFTList(account interface{}, limit interface{}, afterAssetID interface{}) *MockState_NFTList_Call {
+func (_e *MockState_Expecter) NFTList(account any, limit any, afterAssetID any) *MockState_NFTList_Call {
 	return &MockState_NFTList_Call{Call: _e.mock.On("NFTList", account, limit, afterAssetID)}
 }
 
@@ -3212,7 +3212,7 @@ type MockState_NewAddrTransactionsIterator_Call struct {
 
 // NewAddrTransactionsIterator is a helper method to define mock.On call
 //   - addr proto.Address
-func (_e *MockState_Expecter) NewAddrTransactionsIterator(addr interface{}) *MockState_NewAddrTransactionsIterator_Call {
+func (_e *MockState_Expecter) NewAddrTransactionsIterator(addr any) *MockState_NewAddrTransactionsIterator_Call {
 	return &MockState_NewAddrTransactionsIterator_Call{Call: _e.mock.On("NewAddrTransactionsIterator", addr)}
 }
 
@@ -3274,7 +3274,7 @@ type MockState_NewestBlockInfoByHeight_Call struct {
 
 // NewestBlockInfoByHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) NewestBlockInfoByHeight(height interface{}) *MockState_NewestBlockInfoByHeight_Call {
+func (_e *MockState_Expecter) NewestBlockInfoByHeight(height any) *MockState_NewestBlockInfoByHeight_Call {
 	return &MockState_NewestBlockInfoByHeight_Call{Call: _e.mock.On("NewestBlockInfoByHeight", height)}
 }
 
@@ -3336,7 +3336,7 @@ type MockState_NewestHeaderByHeight_Call struct {
 
 // NewestHeaderByHeight is a helper method to define mock.On call
 //   - height uint64
-func (_e *MockState_Expecter) NewestHeaderByHeight(height interface{}) *MockState_NewestHeaderByHeight_Call {
+func (_e *MockState_Expecter) NewestHeaderByHeight(height any) *MockState_NewestHeaderByHeight_Call {
 	return &MockState_NewestHeaderByHeight_Call{Call: _e.mock.On("NewestHeaderByHeight", height)}
 }
 
@@ -3398,7 +3398,7 @@ type MockState_NewestScriptByAccount_Call struct {
 
 // NewestScriptByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) NewestScriptByAccount(account interface{}) *MockState_NewestScriptByAccount_Call {
+func (_e *MockState_Expecter) NewestScriptByAccount(account any) *MockState_NewestScriptByAccount_Call {
 	return &MockState_NewestScriptByAccount_Call{Call: _e.mock.On("NewestScriptByAccount", account)}
 }
 
@@ -3460,7 +3460,7 @@ type MockState_NewestScriptBytesByAccount_Call struct {
 
 // NewestScriptBytesByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) NewestScriptBytesByAccount(account interface{}) *MockState_NewestScriptBytesByAccount_Call {
+func (_e *MockState_Expecter) NewestScriptBytesByAccount(account any) *MockState_NewestScriptBytesByAccount_Call {
 	return &MockState_NewestScriptBytesByAccount_Call{Call: _e.mock.On("NewestScriptBytesByAccount", account)}
 }
 
@@ -3706,7 +3706,7 @@ type MockState_RetrieveBinaryEntry_Call struct {
 // RetrieveBinaryEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockState_Expecter) RetrieveBinaryEntry(account interface{}, key interface{}) *MockState_RetrieveBinaryEntry_Call {
+func (_e *MockState_Expecter) RetrieveBinaryEntry(account any, key any) *MockState_RetrieveBinaryEntry_Call {
 	return &MockState_RetrieveBinaryEntry_Call{Call: _e.mock.On("RetrieveBinaryEntry", account, key)}
 }
 
@@ -3774,7 +3774,7 @@ type MockState_RetrieveBooleanEntry_Call struct {
 // RetrieveBooleanEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockState_Expecter) RetrieveBooleanEntry(account interface{}, key interface{}) *MockState_RetrieveBooleanEntry_Call {
+func (_e *MockState_Expecter) RetrieveBooleanEntry(account any, key any) *MockState_RetrieveBooleanEntry_Call {
 	return &MockState_RetrieveBooleanEntry_Call{Call: _e.mock.On("RetrieveBooleanEntry", account, key)}
 }
 
@@ -3841,7 +3841,7 @@ type MockState_RetrieveEntries_Call struct {
 
 // RetrieveEntries is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) RetrieveEntries(account interface{}) *MockState_RetrieveEntries_Call {
+func (_e *MockState_Expecter) RetrieveEntries(account any) *MockState_RetrieveEntries_Call {
 	return &MockState_RetrieveEntries_Call{Call: _e.mock.On("RetrieveEntries", account)}
 }
 
@@ -3904,7 +3904,7 @@ type MockState_RetrieveEntry_Call struct {
 // RetrieveEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockState_Expecter) RetrieveEntry(account interface{}, key interface{}) *MockState_RetrieveEntry_Call {
+func (_e *MockState_Expecter) RetrieveEntry(account any, key any) *MockState_RetrieveEntry_Call {
 	return &MockState_RetrieveEntry_Call{Call: _e.mock.On("RetrieveEntry", account, key)}
 }
 
@@ -3972,7 +3972,7 @@ type MockState_RetrieveIntegerEntry_Call struct {
 // RetrieveIntegerEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockState_Expecter) RetrieveIntegerEntry(account interface{}, key interface{}) *MockState_RetrieveIntegerEntry_Call {
+func (_e *MockState_Expecter) RetrieveIntegerEntry(account any, key any) *MockState_RetrieveIntegerEntry_Call {
 	return &MockState_RetrieveIntegerEntry_Call{Call: _e.mock.On("RetrieveIntegerEntry", account, key)}
 }
 
@@ -4040,7 +4040,7 @@ type MockState_RetrieveStringEntry_Call struct {
 // RetrieveStringEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockState_Expecter) RetrieveStringEntry(account interface{}, key interface{}) *MockState_RetrieveStringEntry_Call {
+func (_e *MockState_Expecter) RetrieveStringEntry(account any, key any) *MockState_RetrieveStringEntry_Call {
 	return &MockState_RetrieveStringEntry_Call{Call: _e.mock.On("RetrieveStringEntry", account, key)}
 }
 
@@ -4105,7 +4105,7 @@ type MockState_RewardAtHeight_Call struct {
 
 // RewardAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) RewardAtHeight(height interface{}) *MockState_RewardAtHeight_Call {
+func (_e *MockState_Expecter) RewardAtHeight(height any) *MockState_RewardAtHeight_Call {
 	return &MockState_RewardAtHeight_Call{Call: _e.mock.On("RewardAtHeight", height)}
 }
 
@@ -4165,7 +4165,7 @@ type MockState_RewardVotes_Call struct {
 
 // RewardVotes is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) RewardVotes(height interface{}) *MockState_RewardVotes_Call {
+func (_e *MockState_Expecter) RewardVotes(height any) *MockState_RewardVotes_Call {
 	return &MockState_RewardVotes_Call{Call: _e.mock.On("RewardVotes", height)}
 }
 
@@ -4217,7 +4217,7 @@ type MockState_RollbackTo_Call struct {
 // RollbackTo is a helper method to define mock.On call
 //   - removalEdge proto.BlockID
 //   - isAutoRollback bool
-func (_e *MockState_Expecter) RollbackTo(removalEdge interface{}, isAutoRollback interface{}) *MockState_RollbackTo_Call {
+func (_e *MockState_Expecter) RollbackTo(removalEdge any, isAutoRollback any) *MockState_RollbackTo_Call {
 	return &MockState_RollbackTo_Call{Call: _e.mock.On("RollbackTo", removalEdge, isAutoRollback)}
 }
 
@@ -4274,7 +4274,7 @@ type MockState_RollbackToHeight_Call struct {
 // RollbackToHeight is a helper method to define mock.On call
 //   - height proto.Height
 //   - isAutoRollback bool
-func (_e *MockState_Expecter) RollbackToHeight(height interface{}, isAutoRollback interface{}) *MockState_RollbackToHeight_Call {
+func (_e *MockState_Expecter) RollbackToHeight(height any, isAutoRollback any) *MockState_RollbackToHeight_Call {
 	return &MockState_RollbackToHeight_Call{Call: _e.mock.On("RollbackToHeight", height, isAutoRollback)}
 }
 
@@ -4341,7 +4341,7 @@ type MockState_ScoreAtHeight_Call struct {
 
 // ScoreAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) ScoreAtHeight(height interface{}) *MockState_ScoreAtHeight_Call {
+func (_e *MockState_Expecter) ScoreAtHeight(height any) *MockState_ScoreAtHeight_Call {
 	return &MockState_ScoreAtHeight_Call{Call: _e.mock.On("ScoreAtHeight", height)}
 }
 
@@ -4403,7 +4403,7 @@ type MockState_ScriptBasicInfoByAccount_Call struct {
 
 // ScriptBasicInfoByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) ScriptBasicInfoByAccount(account interface{}) *MockState_ScriptBasicInfoByAccount_Call {
+func (_e *MockState_Expecter) ScriptBasicInfoByAccount(account any) *MockState_ScriptBasicInfoByAccount_Call {
 	return &MockState_ScriptBasicInfoByAccount_Call{Call: _e.mock.On("ScriptBasicInfoByAccount", account)}
 }
 
@@ -4465,7 +4465,7 @@ type MockState_ScriptInfoByAccount_Call struct {
 
 // ScriptInfoByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) ScriptInfoByAccount(account interface{}) *MockState_ScriptInfoByAccount_Call {
+func (_e *MockState_Expecter) ScriptInfoByAccount(account any) *MockState_ScriptInfoByAccount_Call {
 	return &MockState_ScriptInfoByAccount_Call{Call: _e.mock.On("ScriptInfoByAccount", account)}
 }
 
@@ -4527,7 +4527,7 @@ type MockState_ScriptInfoByAsset_Call struct {
 
 // ScriptInfoByAsset is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockState_Expecter) ScriptInfoByAsset(assetID interface{}) *MockState_ScriptInfoByAsset_Call {
+func (_e *MockState_Expecter) ScriptInfoByAsset(assetID any) *MockState_ScriptInfoByAsset_Call {
 	return &MockState_ScriptInfoByAsset_Call{Call: _e.mock.On("ScriptInfoByAsset", assetID)}
 }
 
@@ -4642,7 +4642,7 @@ type MockState_SnapshotStateHashAtHeight_Call struct {
 
 // SnapshotStateHashAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) SnapshotStateHashAtHeight(height interface{}) *MockState_SnapshotStateHashAtHeight_Call {
+func (_e *MockState_Expecter) SnapshotStateHashAtHeight(height any) *MockState_SnapshotStateHashAtHeight_Call {
 	return &MockState_SnapshotStateHashAtHeight_Call{Call: _e.mock.On("SnapshotStateHashAtHeight", height)}
 }
 
@@ -4702,7 +4702,7 @@ type MockState_SnapshotsAtHeight_Call struct {
 
 // SnapshotsAtHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) SnapshotsAtHeight(height interface{}) *MockState_SnapshotsAtHeight_Call {
+func (_e *MockState_Expecter) SnapshotsAtHeight(height any) *MockState_SnapshotsAtHeight_Call {
 	return &MockState_SnapshotsAtHeight_Call{Call: _e.mock.On("SnapshotsAtHeight", height)}
 }
 
@@ -4852,7 +4852,7 @@ type MockState_TotalWavesAmount_Call struct {
 
 // TotalWavesAmount is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockState_Expecter) TotalWavesAmount(height interface{}) *MockState_TotalWavesAmount_Call {
+func (_e *MockState_Expecter) TotalWavesAmount(height any) *MockState_TotalWavesAmount_Call {
 	return &MockState_TotalWavesAmount_Call{Call: _e.mock.On("TotalWavesAmount", height)}
 }
 
@@ -4914,7 +4914,7 @@ type MockState_TransactionByID_Call struct {
 
 // TransactionByID is a helper method to define mock.On call
 //   - id []byte
-func (_e *MockState_Expecter) TransactionByID(id interface{}) *MockState_TransactionByID_Call {
+func (_e *MockState_Expecter) TransactionByID(id any) *MockState_TransactionByID_Call {
 	return &MockState_TransactionByID_Call{Call: _e.mock.On("TransactionByID", id)}
 }
 
@@ -4982,7 +4982,7 @@ type MockState_TransactionByIDWithStatus_Call struct {
 
 // TransactionByIDWithStatus is a helper method to define mock.On call
 //   - id []byte
-func (_e *MockState_Expecter) TransactionByIDWithStatus(id interface{}) *MockState_TransactionByIDWithStatus_Call {
+func (_e *MockState_Expecter) TransactionByIDWithStatus(id any) *MockState_TransactionByIDWithStatus_Call {
 	return &MockState_TransactionByIDWithStatus_Call{Call: _e.mock.On("TransactionByIDWithStatus", id)}
 }
 
@@ -5042,7 +5042,7 @@ type MockState_TransactionHeightByID_Call struct {
 
 // TransactionHeightByID is a helper method to define mock.On call
 //   - id []byte
-func (_e *MockState_Expecter) TransactionHeightByID(id interface{}) *MockState_TransactionHeightByID_Call {
+func (_e *MockState_Expecter) TransactionHeightByID(id any) *MockState_TransactionHeightByID_Call {
 	return &MockState_TransactionHeightByID_Call{Call: _e.mock.On("TransactionHeightByID", id)}
 }
 
@@ -5093,7 +5093,7 @@ type MockState_TxValidation_Call struct {
 
 // TxValidation is a helper method to define mock.On call
 //   - fn func(validation TxValidation) error
-func (_e *MockState_Expecter) TxValidation(fn interface{}) *MockState_TxValidation_Call {
+func (_e *MockState_Expecter) TxValidation(fn any) *MockState_TxValidation_Call {
 	return &MockState_TxValidation_Call{Call: _e.mock.On("TxValidation", fn)}
 }
 
@@ -5159,7 +5159,7 @@ type MockState_ValidateNextTx_Call struct {
 //   - parentTimestamp uint64
 //   - blockVersion proto.BlockVersion
 //   - acceptFailed bool
-func (_e *MockState_Expecter) ValidateNextTx(tx interface{}, currentTimestamp interface{}, parentTimestamp interface{}, blockVersion interface{}, acceptFailed interface{}) *MockState_ValidateNextTx_Call {
+func (_e *MockState_Expecter) ValidateNextTx(tx any, currentTimestamp any, parentTimestamp any, blockVersion any, acceptFailed any) *MockState_ValidateNextTx_Call {
 	return &MockState_ValidateNextTx_Call{Call: _e.mock.On("ValidateNextTx", tx, currentTimestamp, parentTimestamp, blockVersion, acceptFailed)}
 }
 
@@ -5239,7 +5239,7 @@ type MockState_VotesNum_Call struct {
 
 // VotesNum is a helper method to define mock.On call
 //   - featureID int16
-func (_e *MockState_Expecter) VotesNum(featureID interface{}) *MockState_VotesNum_Call {
+func (_e *MockState_Expecter) VotesNum(featureID any) *MockState_VotesNum_Call {
 	return &MockState_VotesNum_Call{Call: _e.mock.On("VotesNum", featureID)}
 }
 
@@ -5300,7 +5300,7 @@ type MockState_VotesNumAtHeight_Call struct {
 // VotesNumAtHeight is a helper method to define mock.On call
 //   - featureID int16
 //   - height proto.Height
-func (_e *MockState_Expecter) VotesNumAtHeight(featureID interface{}, height interface{}) *MockState_VotesNumAtHeight_Call {
+func (_e *MockState_Expecter) VotesNumAtHeight(featureID any, height any) *MockState_VotesNumAtHeight_Call {
 	return &MockState_VotesNumAtHeight_Call{Call: _e.mock.On("VotesNumAtHeight", featureID, height)}
 }
 
@@ -5418,7 +5418,7 @@ type MockState_WavesBalance_Call struct {
 
 // WavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockState_Expecter) WavesBalance(account interface{}) *MockState_WavesBalance_Call {
+func (_e *MockState_Expecter) WavesBalance(account any) *MockState_WavesBalance_Call {
 	return &MockState_WavesBalance_Call{Call: _e.mock.On("WavesBalance", account)}
 }
 

--- a/pkg/types/mock_enriched_smart_state.go
+++ b/pkg/types/mock_enriched_smart_state.go
@@ -168,7 +168,7 @@ type MockEnrichedSmartState_IsNotFound_Call struct {
 
 // IsNotFound is a helper method to define mock.On call
 //   - err error
-func (_e *MockEnrichedSmartState_Expecter) IsNotFound(err interface{}) *MockEnrichedSmartState_IsNotFound_Call {
+func (_e *MockEnrichedSmartState_Expecter) IsNotFound(err any) *MockEnrichedSmartState_IsNotFound_Call {
 	return &MockEnrichedSmartState_IsNotFound_Call{Call: _e.mock.On("IsNotFound", err)}
 }
 
@@ -228,7 +228,7 @@ type MockEnrichedSmartState_IsStateUntouched_Call struct {
 
 // IsStateUntouched is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) IsStateUntouched(account interface{}) *MockEnrichedSmartState_IsStateUntouched_Call {
+func (_e *MockEnrichedSmartState_Expecter) IsStateUntouched(account any) *MockEnrichedSmartState_IsStateUntouched_Call {
 	return &MockEnrichedSmartState_IsStateUntouched_Call{Call: _e.mock.On("IsStateUntouched", account)}
 }
 
@@ -290,7 +290,7 @@ type MockEnrichedSmartState_NewestAddrByAlias_Call struct {
 
 // NewestAddrByAlias is a helper method to define mock.On call
 //   - alias proto.Alias
-func (_e *MockEnrichedSmartState_Expecter) NewestAddrByAlias(alias interface{}) *MockEnrichedSmartState_NewestAddrByAlias_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAddrByAlias(alias any) *MockEnrichedSmartState_NewestAddrByAlias_Call {
 	return &MockEnrichedSmartState_NewestAddrByAlias_Call{Call: _e.mock.On("NewestAddrByAlias", alias)}
 }
 
@@ -351,7 +351,7 @@ type MockEnrichedSmartState_NewestAssetBalance_Call struct {
 // NewestAssetBalance is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - assetID crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestAssetBalance(account interface{}, assetID interface{}) *MockEnrichedSmartState_NewestAssetBalance_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAssetBalance(account any, assetID any) *MockEnrichedSmartState_NewestAssetBalance_Call {
 	return &MockEnrichedSmartState_NewestAssetBalance_Call{Call: _e.mock.On("NewestAssetBalance", account, assetID)}
 }
 
@@ -417,7 +417,7 @@ type MockEnrichedSmartState_NewestAssetBalanceByAddressID_Call struct {
 // NewestAssetBalanceByAddressID is a helper method to define mock.On call
 //   - id proto.AddressID
 //   - asset crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestAssetBalanceByAddressID(id interface{}, asset interface{}) *MockEnrichedSmartState_NewestAssetBalanceByAddressID_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAssetBalanceByAddressID(id any, asset any) *MockEnrichedSmartState_NewestAssetBalanceByAddressID_Call {
 	return &MockEnrichedSmartState_NewestAssetBalanceByAddressID_Call{Call: _e.mock.On("NewestAssetBalanceByAddressID", id, asset)}
 }
 
@@ -484,7 +484,7 @@ type MockEnrichedSmartState_NewestAssetConstInfo_Call struct {
 
 // NewestAssetConstInfo is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockEnrichedSmartState_Expecter) NewestAssetConstInfo(assetID interface{}) *MockEnrichedSmartState_NewestAssetConstInfo_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAssetConstInfo(assetID any) *MockEnrichedSmartState_NewestAssetConstInfo_Call {
 	return &MockEnrichedSmartState_NewestAssetConstInfo_Call{Call: _e.mock.On("NewestAssetConstInfo", assetID)}
 }
 
@@ -546,7 +546,7 @@ type MockEnrichedSmartState_NewestAssetInfo_Call struct {
 
 // NewestAssetInfo is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestAssetInfo(assetID interface{}) *MockEnrichedSmartState_NewestAssetInfo_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAssetInfo(assetID any) *MockEnrichedSmartState_NewestAssetInfo_Call {
 	return &MockEnrichedSmartState_NewestAssetInfo_Call{Call: _e.mock.On("NewestAssetInfo", assetID)}
 }
 
@@ -606,7 +606,7 @@ type MockEnrichedSmartState_NewestAssetIsSponsored_Call struct {
 
 // NewestAssetIsSponsored is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestAssetIsSponsored(assetID interface{}) *MockEnrichedSmartState_NewestAssetIsSponsored_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestAssetIsSponsored(assetID any) *MockEnrichedSmartState_NewestAssetIsSponsored_Call {
 	return &MockEnrichedSmartState_NewestAssetIsSponsored_Call{Call: _e.mock.On("NewestAssetIsSponsored", assetID)}
 }
 
@@ -668,7 +668,7 @@ type MockEnrichedSmartState_NewestBlockInfoByHeight_Call struct {
 
 // NewestBlockInfoByHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockEnrichedSmartState_Expecter) NewestBlockInfoByHeight(height interface{}) *MockEnrichedSmartState_NewestBlockInfoByHeight_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestBlockInfoByHeight(height any) *MockEnrichedSmartState_NewestBlockInfoByHeight_Call {
 	return &MockEnrichedSmartState_NewestBlockInfoByHeight_Call{Call: _e.mock.On("NewestBlockInfoByHeight", height)}
 }
 
@@ -730,7 +730,7 @@ type MockEnrichedSmartState_NewestFullAssetInfo_Call struct {
 
 // NewestFullAssetInfo is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestFullAssetInfo(assetID interface{}) *MockEnrichedSmartState_NewestFullAssetInfo_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestFullAssetInfo(assetID any) *MockEnrichedSmartState_NewestFullAssetInfo_Call {
 	return &MockEnrichedSmartState_NewestFullAssetInfo_Call{Call: _e.mock.On("NewestFullAssetInfo", assetID)}
 }
 
@@ -792,7 +792,7 @@ type MockEnrichedSmartState_NewestFullWavesBalance_Call struct {
 
 // NewestFullWavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) NewestFullWavesBalance(account interface{}) *MockEnrichedSmartState_NewestFullWavesBalance_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestFullWavesBalance(account any) *MockEnrichedSmartState_NewestFullWavesBalance_Call {
 	return &MockEnrichedSmartState_NewestFullWavesBalance_Call{Call: _e.mock.On("NewestFullWavesBalance", account)}
 }
 
@@ -854,7 +854,7 @@ type MockEnrichedSmartState_NewestLeasingInfo_Call struct {
 
 // NewestLeasingInfo is a helper method to define mock.On call
 //   - id crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestLeasingInfo(id interface{}) *MockEnrichedSmartState_NewestLeasingInfo_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestLeasingInfo(id any) *MockEnrichedSmartState_NewestLeasingInfo_Call {
 	return &MockEnrichedSmartState_NewestLeasingInfo_Call{Call: _e.mock.On("NewestLeasingInfo", id)}
 }
 
@@ -916,7 +916,7 @@ type MockEnrichedSmartState_NewestRecipientToAddress_Call struct {
 
 // NewestRecipientToAddress is a helper method to define mock.On call
 //   - recipient proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) NewestRecipientToAddress(recipient interface{}) *MockEnrichedSmartState_NewestRecipientToAddress_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestRecipientToAddress(recipient any) *MockEnrichedSmartState_NewestRecipientToAddress_Call {
 	return &MockEnrichedSmartState_NewestRecipientToAddress_Call{Call: _e.mock.On("NewestRecipientToAddress", recipient)}
 }
 
@@ -978,7 +978,7 @@ type MockEnrichedSmartState_NewestScriptByAccount_Call struct {
 
 // NewestScriptByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) NewestScriptByAccount(account interface{}) *MockEnrichedSmartState_NewestScriptByAccount_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestScriptByAccount(account any) *MockEnrichedSmartState_NewestScriptByAccount_Call {
 	return &MockEnrichedSmartState_NewestScriptByAccount_Call{Call: _e.mock.On("NewestScriptByAccount", account)}
 }
 
@@ -1040,7 +1040,7 @@ type MockEnrichedSmartState_NewestScriptByAsset_Call struct {
 
 // NewestScriptByAsset is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockEnrichedSmartState_Expecter) NewestScriptByAsset(assetID interface{}) *MockEnrichedSmartState_NewestScriptByAsset_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestScriptByAsset(assetID any) *MockEnrichedSmartState_NewestScriptByAsset_Call {
 	return &MockEnrichedSmartState_NewestScriptByAsset_Call{Call: _e.mock.On("NewestScriptByAsset", assetID)}
 }
 
@@ -1102,7 +1102,7 @@ type MockEnrichedSmartState_NewestScriptBytesByAccount_Call struct {
 
 // NewestScriptBytesByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) NewestScriptBytesByAccount(account interface{}) *MockEnrichedSmartState_NewestScriptBytesByAccount_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestScriptBytesByAccount(account any) *MockEnrichedSmartState_NewestScriptBytesByAccount_Call {
 	return &MockEnrichedSmartState_NewestScriptBytesByAccount_Call{Call: _e.mock.On("NewestScriptBytesByAccount", account)}
 }
 
@@ -1164,7 +1164,7 @@ type MockEnrichedSmartState_NewestScriptPKByAddr_Call struct {
 
 // NewestScriptPKByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockEnrichedSmartState_Expecter) NewestScriptPKByAddr(addr interface{}) *MockEnrichedSmartState_NewestScriptPKByAddr_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestScriptPKByAddr(addr any) *MockEnrichedSmartState_NewestScriptPKByAddr_Call {
 	return &MockEnrichedSmartState_NewestScriptPKByAddr_Call{Call: _e.mock.On("NewestScriptPKByAddr", addr)}
 }
 
@@ -1226,7 +1226,7 @@ type MockEnrichedSmartState_NewestTransactionByID_Call struct {
 
 // NewestTransactionByID is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *MockEnrichedSmartState_Expecter) NewestTransactionByID(bytes interface{}) *MockEnrichedSmartState_NewestTransactionByID_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestTransactionByID(bytes any) *MockEnrichedSmartState_NewestTransactionByID_Call {
 	return &MockEnrichedSmartState_NewestTransactionByID_Call{Call: _e.mock.On("NewestTransactionByID", bytes)}
 }
 
@@ -1286,7 +1286,7 @@ type MockEnrichedSmartState_NewestTransactionHeightByID_Call struct {
 
 // NewestTransactionHeightByID is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *MockEnrichedSmartState_Expecter) NewestTransactionHeightByID(bytes interface{}) *MockEnrichedSmartState_NewestTransactionHeightByID_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestTransactionHeightByID(bytes any) *MockEnrichedSmartState_NewestTransactionHeightByID_Call {
 	return &MockEnrichedSmartState_NewestTransactionHeightByID_Call{Call: _e.mock.On("NewestTransactionHeightByID", bytes)}
 }
 
@@ -1346,7 +1346,7 @@ type MockEnrichedSmartState_NewestWavesBalance_Call struct {
 
 // NewestWavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) NewestWavesBalance(account interface{}) *MockEnrichedSmartState_NewestWavesBalance_Call {
+func (_e *MockEnrichedSmartState_Expecter) NewestWavesBalance(account any) *MockEnrichedSmartState_NewestWavesBalance_Call {
 	return &MockEnrichedSmartState_NewestWavesBalance_Call{Call: _e.mock.On("NewestWavesBalance", account)}
 }
 
@@ -1408,7 +1408,7 @@ type MockEnrichedSmartState_RetrieveEntries_Call struct {
 
 // RetrieveEntries is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockEnrichedSmartState_Expecter) RetrieveEntries(account interface{}) *MockEnrichedSmartState_RetrieveEntries_Call {
+func (_e *MockEnrichedSmartState_Expecter) RetrieveEntries(account any) *MockEnrichedSmartState_RetrieveEntries_Call {
 	return &MockEnrichedSmartState_RetrieveEntries_Call{Call: _e.mock.On("RetrieveEntries", account)}
 }
 
@@ -1471,7 +1471,7 @@ type MockEnrichedSmartState_RetrieveNewestBinaryEntry_Call struct {
 // RetrieveNewestBinaryEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestBinaryEntry(account interface{}, key interface{}) *MockEnrichedSmartState_RetrieveNewestBinaryEntry_Call {
+func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestBinaryEntry(account any, key any) *MockEnrichedSmartState_RetrieveNewestBinaryEntry_Call {
 	return &MockEnrichedSmartState_RetrieveNewestBinaryEntry_Call{Call: _e.mock.On("RetrieveNewestBinaryEntry", account, key)}
 }
 
@@ -1539,7 +1539,7 @@ type MockEnrichedSmartState_RetrieveNewestBooleanEntry_Call struct {
 // RetrieveNewestBooleanEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestBooleanEntry(account interface{}, key interface{}) *MockEnrichedSmartState_RetrieveNewestBooleanEntry_Call {
+func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestBooleanEntry(account any, key any) *MockEnrichedSmartState_RetrieveNewestBooleanEntry_Call {
 	return &MockEnrichedSmartState_RetrieveNewestBooleanEntry_Call{Call: _e.mock.On("RetrieveNewestBooleanEntry", account, key)}
 }
 
@@ -1607,7 +1607,7 @@ type MockEnrichedSmartState_RetrieveNewestIntegerEntry_Call struct {
 // RetrieveNewestIntegerEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestIntegerEntry(account interface{}, key interface{}) *MockEnrichedSmartState_RetrieveNewestIntegerEntry_Call {
+func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestIntegerEntry(account any, key any) *MockEnrichedSmartState_RetrieveNewestIntegerEntry_Call {
 	return &MockEnrichedSmartState_RetrieveNewestIntegerEntry_Call{Call: _e.mock.On("RetrieveNewestIntegerEntry", account, key)}
 }
 
@@ -1675,7 +1675,7 @@ type MockEnrichedSmartState_RetrieveNewestStringEntry_Call struct {
 // RetrieveNewestStringEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestStringEntry(account interface{}, key interface{}) *MockEnrichedSmartState_RetrieveNewestStringEntry_Call {
+func (_e *MockEnrichedSmartState_Expecter) RetrieveNewestStringEntry(account any, key any) *MockEnrichedSmartState_RetrieveNewestStringEntry_Call {
 	return &MockEnrichedSmartState_RetrieveNewestStringEntry_Call{Call: _e.mock.On("RetrieveNewestStringEntry", account, key)}
 }
 
@@ -1742,7 +1742,7 @@ type MockEnrichedSmartState_WavesBalanceProfile_Call struct {
 
 // WavesBalanceProfile is a helper method to define mock.On call
 //   - id proto.AddressID
-func (_e *MockEnrichedSmartState_Expecter) WavesBalanceProfile(id interface{}) *MockEnrichedSmartState_WavesBalanceProfile_Call {
+func (_e *MockEnrichedSmartState_Expecter) WavesBalanceProfile(id any) *MockEnrichedSmartState_WavesBalanceProfile_Call {
 	return &MockEnrichedSmartState_WavesBalanceProfile_Call{Call: _e.mock.On("WavesBalanceProfile", id)}
 }
 

--- a/pkg/types/mock_smart_state.go
+++ b/pkg/types/mock_smart_state.go
@@ -168,7 +168,7 @@ type MockSmartState_IsNotFound_Call struct {
 
 // IsNotFound is a helper method to define mock.On call
 //   - err error
-func (_e *MockSmartState_Expecter) IsNotFound(err interface{}) *MockSmartState_IsNotFound_Call {
+func (_e *MockSmartState_Expecter) IsNotFound(err any) *MockSmartState_IsNotFound_Call {
 	return &MockSmartState_IsNotFound_Call{Call: _e.mock.On("IsNotFound", err)}
 }
 
@@ -228,7 +228,7 @@ type MockSmartState_IsStateUntouched_Call struct {
 
 // IsStateUntouched is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) IsStateUntouched(account interface{}) *MockSmartState_IsStateUntouched_Call {
+func (_e *MockSmartState_Expecter) IsStateUntouched(account any) *MockSmartState_IsStateUntouched_Call {
 	return &MockSmartState_IsStateUntouched_Call{Call: _e.mock.On("IsStateUntouched", account)}
 }
 
@@ -290,7 +290,7 @@ type MockSmartState_NewestAddrByAlias_Call struct {
 
 // NewestAddrByAlias is a helper method to define mock.On call
 //   - alias proto.Alias
-func (_e *MockSmartState_Expecter) NewestAddrByAlias(alias interface{}) *MockSmartState_NewestAddrByAlias_Call {
+func (_e *MockSmartState_Expecter) NewestAddrByAlias(alias any) *MockSmartState_NewestAddrByAlias_Call {
 	return &MockSmartState_NewestAddrByAlias_Call{Call: _e.mock.On("NewestAddrByAlias", alias)}
 }
 
@@ -351,7 +351,7 @@ type MockSmartState_NewestAssetBalance_Call struct {
 // NewestAssetBalance is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - assetID crypto.Digest
-func (_e *MockSmartState_Expecter) NewestAssetBalance(account interface{}, assetID interface{}) *MockSmartState_NewestAssetBalance_Call {
+func (_e *MockSmartState_Expecter) NewestAssetBalance(account any, assetID any) *MockSmartState_NewestAssetBalance_Call {
 	return &MockSmartState_NewestAssetBalance_Call{Call: _e.mock.On("NewestAssetBalance", account, assetID)}
 }
 
@@ -418,7 +418,7 @@ type MockSmartState_NewestAssetConstInfo_Call struct {
 
 // NewestAssetConstInfo is a helper method to define mock.On call
 //   - assetID proto.AssetID
-func (_e *MockSmartState_Expecter) NewestAssetConstInfo(assetID interface{}) *MockSmartState_NewestAssetConstInfo_Call {
+func (_e *MockSmartState_Expecter) NewestAssetConstInfo(assetID any) *MockSmartState_NewestAssetConstInfo_Call {
 	return &MockSmartState_NewestAssetConstInfo_Call{Call: _e.mock.On("NewestAssetConstInfo", assetID)}
 }
 
@@ -480,7 +480,7 @@ type MockSmartState_NewestAssetInfo_Call struct {
 
 // NewestAssetInfo is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockSmartState_Expecter) NewestAssetInfo(assetID interface{}) *MockSmartState_NewestAssetInfo_Call {
+func (_e *MockSmartState_Expecter) NewestAssetInfo(assetID any) *MockSmartState_NewestAssetInfo_Call {
 	return &MockSmartState_NewestAssetInfo_Call{Call: _e.mock.On("NewestAssetInfo", assetID)}
 }
 
@@ -540,7 +540,7 @@ type MockSmartState_NewestAssetIsSponsored_Call struct {
 
 // NewestAssetIsSponsored is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockSmartState_Expecter) NewestAssetIsSponsored(assetID interface{}) *MockSmartState_NewestAssetIsSponsored_Call {
+func (_e *MockSmartState_Expecter) NewestAssetIsSponsored(assetID any) *MockSmartState_NewestAssetIsSponsored_Call {
 	return &MockSmartState_NewestAssetIsSponsored_Call{Call: _e.mock.On("NewestAssetIsSponsored", assetID)}
 }
 
@@ -602,7 +602,7 @@ type MockSmartState_NewestBlockInfoByHeight_Call struct {
 
 // NewestBlockInfoByHeight is a helper method to define mock.On call
 //   - height proto.Height
-func (_e *MockSmartState_Expecter) NewestBlockInfoByHeight(height interface{}) *MockSmartState_NewestBlockInfoByHeight_Call {
+func (_e *MockSmartState_Expecter) NewestBlockInfoByHeight(height any) *MockSmartState_NewestBlockInfoByHeight_Call {
 	return &MockSmartState_NewestBlockInfoByHeight_Call{Call: _e.mock.On("NewestBlockInfoByHeight", height)}
 }
 
@@ -664,7 +664,7 @@ type MockSmartState_NewestFullAssetInfo_Call struct {
 
 // NewestFullAssetInfo is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockSmartState_Expecter) NewestFullAssetInfo(assetID interface{}) *MockSmartState_NewestFullAssetInfo_Call {
+func (_e *MockSmartState_Expecter) NewestFullAssetInfo(assetID any) *MockSmartState_NewestFullAssetInfo_Call {
 	return &MockSmartState_NewestFullAssetInfo_Call{Call: _e.mock.On("NewestFullAssetInfo", assetID)}
 }
 
@@ -726,7 +726,7 @@ type MockSmartState_NewestFullWavesBalance_Call struct {
 
 // NewestFullWavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) NewestFullWavesBalance(account interface{}) *MockSmartState_NewestFullWavesBalance_Call {
+func (_e *MockSmartState_Expecter) NewestFullWavesBalance(account any) *MockSmartState_NewestFullWavesBalance_Call {
 	return &MockSmartState_NewestFullWavesBalance_Call{Call: _e.mock.On("NewestFullWavesBalance", account)}
 }
 
@@ -788,7 +788,7 @@ type MockSmartState_NewestLeasingInfo_Call struct {
 
 // NewestLeasingInfo is a helper method to define mock.On call
 //   - id crypto.Digest
-func (_e *MockSmartState_Expecter) NewestLeasingInfo(id interface{}) *MockSmartState_NewestLeasingInfo_Call {
+func (_e *MockSmartState_Expecter) NewestLeasingInfo(id any) *MockSmartState_NewestLeasingInfo_Call {
 	return &MockSmartState_NewestLeasingInfo_Call{Call: _e.mock.On("NewestLeasingInfo", id)}
 }
 
@@ -850,7 +850,7 @@ type MockSmartState_NewestRecipientToAddress_Call struct {
 
 // NewestRecipientToAddress is a helper method to define mock.On call
 //   - recipient proto.Recipient
-func (_e *MockSmartState_Expecter) NewestRecipientToAddress(recipient interface{}) *MockSmartState_NewestRecipientToAddress_Call {
+func (_e *MockSmartState_Expecter) NewestRecipientToAddress(recipient any) *MockSmartState_NewestRecipientToAddress_Call {
 	return &MockSmartState_NewestRecipientToAddress_Call{Call: _e.mock.On("NewestRecipientToAddress", recipient)}
 }
 
@@ -912,7 +912,7 @@ type MockSmartState_NewestScriptByAccount_Call struct {
 
 // NewestScriptByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) NewestScriptByAccount(account interface{}) *MockSmartState_NewestScriptByAccount_Call {
+func (_e *MockSmartState_Expecter) NewestScriptByAccount(account any) *MockSmartState_NewestScriptByAccount_Call {
 	return &MockSmartState_NewestScriptByAccount_Call{Call: _e.mock.On("NewestScriptByAccount", account)}
 }
 
@@ -974,7 +974,7 @@ type MockSmartState_NewestScriptByAsset_Call struct {
 
 // NewestScriptByAsset is a helper method to define mock.On call
 //   - assetID crypto.Digest
-func (_e *MockSmartState_Expecter) NewestScriptByAsset(assetID interface{}) *MockSmartState_NewestScriptByAsset_Call {
+func (_e *MockSmartState_Expecter) NewestScriptByAsset(assetID any) *MockSmartState_NewestScriptByAsset_Call {
 	return &MockSmartState_NewestScriptByAsset_Call{Call: _e.mock.On("NewestScriptByAsset", assetID)}
 }
 
@@ -1036,7 +1036,7 @@ type MockSmartState_NewestScriptBytesByAccount_Call struct {
 
 // NewestScriptBytesByAccount is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) NewestScriptBytesByAccount(account interface{}) *MockSmartState_NewestScriptBytesByAccount_Call {
+func (_e *MockSmartState_Expecter) NewestScriptBytesByAccount(account any) *MockSmartState_NewestScriptBytesByAccount_Call {
 	return &MockSmartState_NewestScriptBytesByAccount_Call{Call: _e.mock.On("NewestScriptBytesByAccount", account)}
 }
 
@@ -1098,7 +1098,7 @@ type MockSmartState_NewestScriptPKByAddr_Call struct {
 
 // NewestScriptPKByAddr is a helper method to define mock.On call
 //   - addr proto.WavesAddress
-func (_e *MockSmartState_Expecter) NewestScriptPKByAddr(addr interface{}) *MockSmartState_NewestScriptPKByAddr_Call {
+func (_e *MockSmartState_Expecter) NewestScriptPKByAddr(addr any) *MockSmartState_NewestScriptPKByAddr_Call {
 	return &MockSmartState_NewestScriptPKByAddr_Call{Call: _e.mock.On("NewestScriptPKByAddr", addr)}
 }
 
@@ -1160,7 +1160,7 @@ type MockSmartState_NewestTransactionByID_Call struct {
 
 // NewestTransactionByID is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *MockSmartState_Expecter) NewestTransactionByID(bytes interface{}) *MockSmartState_NewestTransactionByID_Call {
+func (_e *MockSmartState_Expecter) NewestTransactionByID(bytes any) *MockSmartState_NewestTransactionByID_Call {
 	return &MockSmartState_NewestTransactionByID_Call{Call: _e.mock.On("NewestTransactionByID", bytes)}
 }
 
@@ -1220,7 +1220,7 @@ type MockSmartState_NewestTransactionHeightByID_Call struct {
 
 // NewestTransactionHeightByID is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *MockSmartState_Expecter) NewestTransactionHeightByID(bytes interface{}) *MockSmartState_NewestTransactionHeightByID_Call {
+func (_e *MockSmartState_Expecter) NewestTransactionHeightByID(bytes any) *MockSmartState_NewestTransactionHeightByID_Call {
 	return &MockSmartState_NewestTransactionHeightByID_Call{Call: _e.mock.On("NewestTransactionHeightByID", bytes)}
 }
 
@@ -1280,7 +1280,7 @@ type MockSmartState_NewestWavesBalance_Call struct {
 
 // NewestWavesBalance is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) NewestWavesBalance(account interface{}) *MockSmartState_NewestWavesBalance_Call {
+func (_e *MockSmartState_Expecter) NewestWavesBalance(account any) *MockSmartState_NewestWavesBalance_Call {
 	return &MockSmartState_NewestWavesBalance_Call{Call: _e.mock.On("NewestWavesBalance", account)}
 }
 
@@ -1342,7 +1342,7 @@ type MockSmartState_RetrieveEntries_Call struct {
 
 // RetrieveEntries is a helper method to define mock.On call
 //   - account proto.Recipient
-func (_e *MockSmartState_Expecter) RetrieveEntries(account interface{}) *MockSmartState_RetrieveEntries_Call {
+func (_e *MockSmartState_Expecter) RetrieveEntries(account any) *MockSmartState_RetrieveEntries_Call {
 	return &MockSmartState_RetrieveEntries_Call{Call: _e.mock.On("RetrieveEntries", account)}
 }
 
@@ -1405,7 +1405,7 @@ type MockSmartState_RetrieveNewestBinaryEntry_Call struct {
 // RetrieveNewestBinaryEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockSmartState_Expecter) RetrieveNewestBinaryEntry(account interface{}, key interface{}) *MockSmartState_RetrieveNewestBinaryEntry_Call {
+func (_e *MockSmartState_Expecter) RetrieveNewestBinaryEntry(account any, key any) *MockSmartState_RetrieveNewestBinaryEntry_Call {
 	return &MockSmartState_RetrieveNewestBinaryEntry_Call{Call: _e.mock.On("RetrieveNewestBinaryEntry", account, key)}
 }
 
@@ -1473,7 +1473,7 @@ type MockSmartState_RetrieveNewestBooleanEntry_Call struct {
 // RetrieveNewestBooleanEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockSmartState_Expecter) RetrieveNewestBooleanEntry(account interface{}, key interface{}) *MockSmartState_RetrieveNewestBooleanEntry_Call {
+func (_e *MockSmartState_Expecter) RetrieveNewestBooleanEntry(account any, key any) *MockSmartState_RetrieveNewestBooleanEntry_Call {
 	return &MockSmartState_RetrieveNewestBooleanEntry_Call{Call: _e.mock.On("RetrieveNewestBooleanEntry", account, key)}
 }
 
@@ -1541,7 +1541,7 @@ type MockSmartState_RetrieveNewestIntegerEntry_Call struct {
 // RetrieveNewestIntegerEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockSmartState_Expecter) RetrieveNewestIntegerEntry(account interface{}, key interface{}) *MockSmartState_RetrieveNewestIntegerEntry_Call {
+func (_e *MockSmartState_Expecter) RetrieveNewestIntegerEntry(account any, key any) *MockSmartState_RetrieveNewestIntegerEntry_Call {
 	return &MockSmartState_RetrieveNewestIntegerEntry_Call{Call: _e.mock.On("RetrieveNewestIntegerEntry", account, key)}
 }
 
@@ -1609,7 +1609,7 @@ type MockSmartState_RetrieveNewestStringEntry_Call struct {
 // RetrieveNewestStringEntry is a helper method to define mock.On call
 //   - account proto.Recipient
 //   - key string
-func (_e *MockSmartState_Expecter) RetrieveNewestStringEntry(account interface{}, key interface{}) *MockSmartState_RetrieveNewestStringEntry_Call {
+func (_e *MockSmartState_Expecter) RetrieveNewestStringEntry(account any, key any) *MockSmartState_RetrieveNewestStringEntry_Call {
 	return &MockSmartState_RetrieveNewestStringEntry_Call{Call: _e.mock.On("RetrieveNewestStringEntry", account, key)}
 }
 


### PR DESCRIPTION
This pull request introduces a new API endpoint to allow blacklisting peers via HTTP POST, and also includes a series of minor refactors to test mocks for improved type usage. The main change is the addition of the `debug/blacklist` endpoint, which enables clients to blacklist a peer address with proper validation and logging. The rest of the changes are refactors to use the `any` type instead of `interface{}` in generated test mocks, improving code clarity and consistency.

**New API endpoint for peer blacklisting:**

* Added a new POST endpoint `/blacklist` in the authenticated API routes, allowing clients to blacklist a peer by address. The endpoint reads the address from the request body, validates it, and records the blacklist action along with the client's IP and request ID for auditing. (`pkg/api/node_api.go`, `pkg/api/peers.go`, `pkg/api/routes.go`) [[1]](diffhunk://#diff-fffddc18ce7546b6d9bc6dd9d6daf3527b68e14bad40918d20fd3a215c6147e7R643-R659) [[2]](diffhunk://#diff-893004664d3bd32848133b6efbb63b95fe4adc4e2c3e683f6faf0997604e1948R158-R172) [[3]](diffhunk://#diff-20343ca31da2491d1160ba5ed434f5dfa0698341d7ed516306872ebe03758b49R174)

**Dependency and middleware improvements:**

* Added the `github.com/go-chi/chi/v5/middleware` import to enable request context features such as extracting request IDs and client IPs. (`pkg/api/node_api.go`)

**Test mock refactors for type usage:**

* Updated all generated mock expectation methods to use the `any` type instead of `interface{}` for their parameters, following modern Go conventions for improved readability and type safety. (`pkg/blockchaininfo/mocks_test.go`, `pkg/consensus/mock_state_info_provider_test.go`, `pkg/grpc/server/mock_grpc_handlers_test.go`) [[1]](diffhunk://#diff-cdb3551ef39aba38d89361a410d9fef33ca197ab7dba6b7a7f58d8b9a889e81aL114-R114) [[2]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL74-R74) [[3]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL134-R134) [[4]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL194-R194) [[5]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL256-R256) [[6]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL317-R317) [[7]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL383-R383) [[8]](diffhunk://#diff-31948bc7e1086b6461930a90af39c5a3fa80c78eb64d91a02d10d8b1f9eaa2beL440-R440) [[9]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L81-R81) [[10]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L149-R149) [[11]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L206-R206) [[12]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L263-R263) [[13]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L331-R331) [[14]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L399-R399) [[15]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L456-R456) [[16]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L524-R524) [[17]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L592-R592) [[18]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L649-R649) [[19]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L717-R717) [[20]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L774-R774) [[21]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L842-R842) [[22]](diffhunk://#diff-ad3d33e726445c25b7f3ca77a8ea6cd2c19d4aeaa4e0326524dec373fd92abd0L899-R899)