### PR TITLE
Fix for 'debug/blacklist' HTTP API method.

### DIFF
--- a/pkg/api/node_api.go
+++ b/pkg/api/node_api.go
@@ -658,7 +658,15 @@ func (a *NodeApi) PeersBlackList(w http.ResponseWriter, r *http.Request) error {
 	if clientIP == "" {
 		clientIP = r.RemoteAddr
 	}
-	return a.app.PeersBlackList(bodyStr, requestID, clientIP)
+	err = a.app.PeersBlackList(bodyStr, requestID, clientIP)
+	if err != nil {
+		return errors.Wrap(err, "PeersBlackList: failed to blacklist peer")
+	}
+	_, err = io.WriteString(w, http.StatusText(http.StatusOK))
+	if err != nil {
+		return errors.Wrap(err, "PeersBlackList: failed to write response")
+	}
+	return nil
 }
 
 func (a *NodeApi) BlocksGenerators(w http.ResponseWriter, _ *http.Request) error {

--- a/pkg/api/node_api_test.go
+++ b/pkg/api/node_api_test.go
@@ -265,7 +265,7 @@ func (failingReader) Read([]byte) (int, error) {
 }
 
 func TestNodeApi_PeersBlackList(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
+	t.Run("success ip:port", func(t *testing.T) {
 		cfg := &settings.BlockchainSettings{
 			FunctionalitySettings: settings.FunctionalitySettings{
 				GenerationPeriod: 0,
@@ -276,11 +276,10 @@ func TestNodeApi_PeersBlackList(t *testing.T) {
 
 		const blacklistedIP = "5.3.6.7"
 		const blacklistedPort = 6868
-		blacklistedAddr := proto.NewTCPAddr(net.ParseIP(blacklistedIP), blacklistedPort)
 
-		peerManager.EXPECT().AddToBlackListByAddr(
+		peerManager.EXPECT().AddToBlackListByIP(
 			mock.MatchedBy(func(addr proto.TCPAddr) bool {
-				return addr.String() == blacklistedAddr.String()
+				return addr.String() == blacklistedIP+":0"
 			}),
 			mock.MatchedBy(func(t any) bool { return true }),
 			mock.MatchedBy(func(reason string) bool { return reason != "" }),
@@ -301,9 +300,50 @@ func TestNodeApi_PeersBlackList(t *testing.T) {
 
 		err = api.PeersBlackList(resp, req)
 		require.NoError(t, err)
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusText(http.StatusOK), string(respBody))
 	})
 
-	t.Run("success with leading slash", func(t *testing.T) {
+	t.Run("success ip:port", func(t *testing.T) {
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		peerManager := peers.NewMockPeerManager(t)
+
+		const blacklistedIP = "4.3.9.1"
+
+		peerManager.EXPECT().AddToBlackListByIP(
+			mock.MatchedBy(func(addr proto.TCPAddr) bool {
+				return addr.String() == blacklistedIP+":0"
+			}),
+			mock.MatchedBy(func(t any) bool { return true }),
+			mock.MatchedBy(func(reason string) bool { return reason != "" }),
+		).Return().Times(1)
+
+		app, err := NewApp("", nil, services.Services{
+			Peers:  peerManager,
+			Scheme: proto.TestNetScheme,
+		}, cfg)
+		require.NoError(t, err)
+
+		api := NewNodeAPI(app, nil)
+
+		// Test with body containing IP (no leading slash)
+		req := httptest.NewRequest(http.MethodPost, "/peers/blacklist", strings.NewReader(blacklistedIP))
+		resp := httptest.NewRecorder()
+
+		err = api.PeersBlackList(resp, req)
+		require.NoError(t, err)
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusText(http.StatusOK), string(respBody))
+	})
+
+	t.Run("success ip:port with leading slash", func(t *testing.T) {
 		cfg := &settings.BlockchainSettings{
 			FunctionalitySettings: settings.FunctionalitySettings{
 				GenerationPeriod: 0,
@@ -314,10 +354,10 @@ func TestNodeApi_PeersBlackList(t *testing.T) {
 
 		const blacklistedIP = "10.0.0.1"
 		const blacklistedPort = 6868
-		blacklistedAddr := proto.NewTCPAddr(net.ParseIP(blacklistedIP), blacklistedPort)
+		blacklistedAddr := proto.NewTCPAddr(net.ParseIP(blacklistedIP), 0)
 
 		// Handler strips leading slash, so the app receives without it
-		peerManager.EXPECT().AddToBlackListByAddr(
+		peerManager.EXPECT().AddToBlackListByIP(
 			mock.MatchedBy(func(addr proto.TCPAddr) bool {
 				return addr.String() == blacklistedAddr.String()
 			}),
@@ -340,6 +380,9 @@ func TestNodeApi_PeersBlackList(t *testing.T) {
 
 		err = api.PeersBlackList(resp, req)
 		require.NoError(t, err)
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusText(http.StatusOK), string(respBody))
 	})
 
 	t.Run("error reading body", func(t *testing.T) {

--- a/pkg/api/node_api_test.go
+++ b/pkg/api/node_api_test.go
@@ -305,7 +305,7 @@ func TestNodeApi_PeersBlackList(t *testing.T) {
 		assert.Equal(t, http.StatusText(http.StatusOK), string(respBody))
 	})
 
-	t.Run("success ip:port", func(t *testing.T) {
+	t.Run("success ip", func(t *testing.T) {
 		cfg := &settings.BlockchainSettings{
 			FunctionalitySettings: settings.FunctionalitySettings{
 				GenerationPeriod: 0,

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -163,8 +163,8 @@ func resolveAddrToIPsV4(addr string) ([]net.IP, error) {
 	if err != nil {
 		return proto.ResolveHostToIPsv4(addr) // try resolve addr as a host
 	}
-	if _, pErr := strconv.ParseUint(port, 10, 16); pErr != nil { // validate port num
-		return nil, errors.Errorf("invalid port %q", port)
+	if pNum, pErr := strconv.ParseUint(port, 10, 16); pErr != nil || pNum == 0 { // validate port num
+		return nil, errors.Errorf("invalid port '%s'", port)
 	}
 	return proto.ResolveHostToIPsv4(host)
 }

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"time"
 
 	"github.com/pkg/errors"
@@ -156,22 +157,35 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 	return out
 }
 
+func resolveAddrToIPsV4(addr string) ([]net.IP, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return proto.ResolveHostToIPsv4(addr) // try resolve addr as a host
+	}
+	return proto.ResolveHostToIPsv4(host)
+}
+
 func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
-	tcpAddr := proto.NewTCPAddrFromString(blacklistedAddr)
-	if tcpAddr.Empty() {
+	iPsv4, err := resolveAddrToIPsV4(blacklistedAddr)
+	if err != nil {
 		slog.Info("Invalid peer's address to blacklist",
 			slog.String("address", blacklistedAddr),
 			slog.String("client-ip", clientIP),
 			slog.String("request-id", requestID),
 		)
-		return apiErrs.NewBadRequestError(errors.Errorf("invalid address format: %s", blacklistedAddr))
+		return apiErrs.NewBadRequestError(errors.Wrapf(err,
+			"failed to resolve blacklisted host '%s'", blacklistedAddr,
+		))
 	}
 	now := time.Now().UTC()
 	reason := fmt.Sprintf(
-		"blacklisted by API at now='%s' by client='%s' with request-id='%s' address='%s'",
-		now.Format(time.RFC3339), clientIP, requestID, tcpAddr.String(),
+		"blacklisted by API at now='%s' by client='%s' with request-id='%s' addresses='%v'",
+		now.Format(time.RFC3339), clientIP, requestID, iPsv4,
 	)
-	a.peers.AddToBlackListByAddr(tcpAddr, now, reason)
+	for _, ip := range iPsv4 {
+		ipAddr := proto.NewTCPAddr(ip, 0)
+		a.peers.AddToBlackListByIP(ipAddr, now, reason)
+	}
 	return nil
 }
 

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -169,6 +169,17 @@ func resolveAddrToIPsV4(addr string) ([]net.IP, error) {
 	return proto.ResolveHostToIPsv4(host)
 }
 
+func filterUnspecifiedIPs(ips []net.IP) []net.IP {
+	filtered := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip.IsUnspecified() {
+			continue
+		}
+		filtered = append(filtered, ip)
+	}
+	return filtered
+}
+
 func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error {
 	iPsv4, err := resolveAddrToIPsV4(blacklistedAddr)
 	if err != nil {
@@ -181,12 +192,24 @@ func (a *App) PeersBlackList(blacklistedAddr, requestID, clientIP string) error 
 			"failed to resolve blacklisted host '%s'", blacklistedAddr,
 		))
 	}
+	iPsv4Filtered := filterUnspecifiedIPs(iPsv4)
+	if len(iPsv4Filtered) == 0 {
+		slog.Warn("No peer's blacklisted host found",
+			slog.String("address", blacklistedAddr),
+			slog.String("client-ip", clientIP),
+			slog.String("request-id", requestID),
+			slog.Any("resolved-ips", iPsv4),
+		)
+		return apiErrs.NewBadRequestError(errors.Errorf(
+			"no valid IPs found for blacklisted host '%s'", blacklistedAddr,
+		))
+	}
 	now := time.Now().UTC()
 	reason := fmt.Sprintf(
 		"blacklisted by API at now='%s' by client='%s' with request-id='%s' addresses='%v'",
-		now.Format(time.RFC3339), clientIP, requestID, iPsv4,
+		now.Format(time.RFC3339), clientIP, requestID, iPsv4Filtered,
 	)
-	for _, ip := range iPsv4 {
+	for _, ip := range iPsv4Filtered {
 		ipAddr := proto.NewTCPAddr(ip, 0)
 		a.peers.AddToBlackListByIP(ipAddr, now, reason)
 	}

--- a/pkg/api/peers.go
+++ b/pkg/api/peers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -158,9 +159,12 @@ func (a *App) PeersBlackListed() []RestrictedPeerInfo {
 }
 
 func resolveAddrToIPsV4(addr string) ([]net.IP, error) {
-	host, _, err := net.SplitHostPort(addr)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return proto.ResolveHostToIPsv4(addr) // try resolve addr as a host
+	}
+	if _, pErr := strconv.ParseUint(port, 10, 16); pErr != nil { // validate port num
+		return nil, errors.Errorf("invalid port %q", port)
 	}
 	return proto.ResolveHostToIPsv4(host)
 }

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -153,27 +153,35 @@ func TestApp_PeersBlackList(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("ip:bad_port", func(t *testing.T) {
-		const (
-			blacklistedIP   = "5.3.6.7"
-			blacklistedPort = "bad"
-			blacklistedAddr = blacklistedIP + ":" + blacklistedPort
-		)
-		peerManager := peers.NewMockPeerManager(t)
-		cfg := &settings.BlockchainSettings{
-			FunctionalitySettings: settings.FunctionalitySettings{
-				GenerationPeriod: 0,
-			},
+		doTest := func(t *testing.T, port string) {
+			const (
+				blacklistedIP = "5.3.6.7"
+			)
+			peerManager := peers.NewMockPeerManager(t)
+			cfg := &settings.BlockchainSettings{
+				FunctionalitySettings: settings.FunctionalitySettings{
+					GenerationPeriod: 0,
+				},
+			}
+
+			app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+			require.NoError(t, err)
+
+			blacklistedAddr := blacklistedIP + ":" + port
+			err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
+			require.Error(t, err)
+			uErr := stderrs.Unwrap(err)
+			require.Error(t, uErr)
+			require.EqualError(t, uErr, fmt.Sprintf(
+				"failed to resolve blacklisted host '5.3.6.7:%s': invalid port '%s'", port, port,
+			))
+			require.Equal(t, errors.NewBadRequestError(uErr), err)
 		}
-
-		app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
-		require.NoError(t, err)
-
-		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
-		require.Error(t, err)
-		uErr := stderrs.Unwrap(err)
-		require.Error(t, uErr)
-		require.EqualError(t, uErr, "failed to resolve blacklisted host '5.3.6.7:bad': invalid port \"bad\"")
-		require.Equal(t, errors.NewBadRequestError(uErr), err)
+		for i, v := range []string{"bad", "0"} {
+			t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
+				doTest(t, v)
+			})
+		}
 	})
 	t.Run("ip", func(t *testing.T) {
 		const blacklistedAddr = "5.3.6.7"
@@ -221,7 +229,7 @@ func TestApp_PeersBlackList(t *testing.T) {
 			require.EqualError(t, uErr, fmt.Sprintf("no valid IPs found for blacklisted host '%s'", addr))
 			require.Equal(t, errors.NewBadRequestError(uErr), err)
 		}
-		for i, v := range []string{"", ":0", "0.0.0.0", "0.0.0.0:0"} {
+		for i, v := range []string{"", ":21", "0.0.0.0", "0.0.0.0:42"} {
 			t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
 				doTest(t, v)
 			})

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	stderrs "errors"
 	"net"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wavesplatform/gowaves/pkg/api/errors"
 	"github.com/wavesplatform/gowaves/pkg/node/peers"
 	"github.com/wavesplatform/gowaves/pkg/node/peers/storage"
 	"github.com/wavesplatform/gowaves/pkg/proto"
@@ -148,6 +150,29 @@ func TestApp_PeersBlackList(t *testing.T) {
 
 		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
 		require.NoError(t, err)
+	})
+	t.Run("ip:bad_port", func(t *testing.T) {
+		const (
+			blacklistedIP   = "5.3.6.7"
+			blacklistedPort = "bad"
+			blacklistedAddr = blacklistedIP + ":" + blacklistedPort
+		)
+		peerManager := peers.NewMockPeerManager(t)
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+		require.NoError(t, err)
+
+		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
+		require.Error(t, err)
+		uErr := stderrs.Unwrap(err)
+		require.Error(t, uErr)
+		require.EqualError(t, uErr, "failed to resolve blacklisted host '5.3.6.7:bad': invalid port \"bad\"")
+		require.Equal(t, errors.NewBadRequestError(uErr), err)
 	})
 	t.Run("ip", func(t *testing.T) {
 		const blacklistedAddr = "5.3.6.7"

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -114,35 +114,66 @@ func TestApp_PeersAll(t *testing.T) {
 }
 
 func TestApp_PeersBlackList(t *testing.T) {
-	peerManager := peers.NewMockPeerManager(t)
-
 	const (
-		blacklistedAddr = "5.3.6.7:6868"
-		requestID       = "request-123"
-		clientIP        = "192.168.1.1"
+		requestID = "request-123"
+		clientIP  = "192.168.1.1"
 	)
+	t.Run("ip:port", func(t *testing.T) {
+		const (
+			blacklistedIP   = "5.3.6.7"
+			blacklistedPort = "6868"
+			blacklistedAddr = blacklistedIP + ":" + blacklistedPort
+		)
+		peerManager := peers.NewMockPeerManager(t)
+		peerManager.EXPECT().AddToBlackListByIP(
+			mock.MatchedBy(func(addr proto.TCPAddr) bool {
+				return addr.String() == blacklistedIP+":0" // because port is ignored in the blacklist
+			}),
+			mock.MatchedBy(func(t time.Time) bool {
+				return !t.IsZero()
+			}),
+			mock.MatchedBy(func(reason string) bool {
+				return reason != ""
+			}),
+		).Return()
 
-	peerManager.EXPECT().AddToBlackListByAddr(
-		mock.MatchedBy(func(addr proto.TCPAddr) bool {
-			return addr.String() == blacklistedAddr
-		}),
-		mock.MatchedBy(func(t time.Time) bool {
-			return !t.IsZero()
-		}),
-		mock.MatchedBy(func(reason string) bool {
-			return reason != ""
-		}),
-	).Return()
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
 
-	cfg := &settings.BlockchainSettings{
-		FunctionalitySettings: settings.FunctionalitySettings{
-			GenerationPeriod: 0,
-		},
-	}
+		app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+		require.NoError(t, err)
 
-	app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
-	require.NoError(t, err)
+		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
+		require.NoError(t, err)
+	})
+	t.Run("ip", func(t *testing.T) {
+		const blacklistedAddr = "5.3.6.7"
+		peerManager := peers.NewMockPeerManager(t)
+		peerManager.EXPECT().AddToBlackListByIP(
+			mock.MatchedBy(func(addr proto.TCPAddr) bool {
+				return addr.String() == blacklistedAddr+":0"
+			}),
+			mock.MatchedBy(func(t time.Time) bool {
+				return !t.IsZero()
+			}),
+			mock.MatchedBy(func(reason string) bool {
+				return reason != ""
+			}),
+		).Return()
 
-	err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
-	require.NoError(t, err)
+		cfg := &settings.BlockchainSettings{
+			FunctionalitySettings: settings.FunctionalitySettings{
+				GenerationPeriod: 0,
+			},
+		}
+
+		app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+		require.NoError(t, err)
+
+		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/api/peers_test.go
+++ b/pkg/api/peers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	stderrs "errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -200,5 +201,30 @@ func TestApp_PeersBlackList(t *testing.T) {
 
 		err = app.PeersBlackList(blacklistedAddr, requestID, clientIP)
 		require.NoError(t, err)
+	})
+	t.Run("unspecified_ip", func(t *testing.T) {
+		doTest := func(t *testing.T, addr string) {
+			peerManager := peers.NewMockPeerManager(t)
+			cfg := &settings.BlockchainSettings{
+				FunctionalitySettings: settings.FunctionalitySettings{
+					GenerationPeriod: 0,
+				},
+			}
+
+			app, err := NewApp("key", nil, services.Services{Peers: peerManager}, cfg)
+			require.NoError(t, err)
+
+			err = app.PeersBlackList(addr, requestID, clientIP)
+			require.Error(t, err)
+			uErr := stderrs.Unwrap(err)
+			require.Error(t, uErr)
+			require.EqualError(t, uErr, fmt.Sprintf("no valid IPs found for blacklisted host '%s'", addr))
+			require.Equal(t, errors.NewBadRequestError(uErr), err)
+		}
+		for i, v := range []string{"", ":0", "0.0.0.0", "0.0.0.0:0"} {
+			t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
+				doTest(t, v)
+			})
+		}
 	})
 }

--- a/pkg/node/peers/mock_peer_manager.go
+++ b/pkg/node/peers/mock_peer_manager.go
@@ -94,26 +94,26 @@ func (_c *MockPeerManager_AddToBlackList_Call) RunAndReturn(run func(peer1 peer.
 	return _c
 }
 
-// AddToBlackListByAddr provides a mock function for the type MockPeerManager
-func (_mock *MockPeerManager) AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string) {
+// AddToBlackListByIP provides a mock function for the type MockPeerManager
+func (_mock *MockPeerManager) AddToBlackListByIP(addr proto.TCPAddr, blockTime time.Time, reason string) {
 	_mock.Called(addr, blockTime, reason)
 	return
 }
 
-// MockPeerManager_AddToBlackListByAddr_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBlackListByAddr'
-type MockPeerManager_AddToBlackListByAddr_Call struct {
+// MockPeerManager_AddToBlackListByIP_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBlackListByIP'
+type MockPeerManager_AddToBlackListByIP_Call struct {
 	*mock.Call
 }
 
-// AddToBlackListByAddr is a helper method to define mock.On call
+// AddToBlackListByIP is a helper method to define mock.On call
 //   - addr proto.TCPAddr
 //   - blockTime time.Time
 //   - reason string
-func (_e *MockPeerManager_Expecter) AddToBlackListByAddr(addr any, blockTime any, reason any) *MockPeerManager_AddToBlackListByAddr_Call {
-	return &MockPeerManager_AddToBlackListByAddr_Call{Call: _e.mock.On("AddToBlackListByAddr", addr, blockTime, reason)}
+func (_e *MockPeerManager_Expecter) AddToBlackListByIP(addr any, blockTime any, reason any) *MockPeerManager_AddToBlackListByIP_Call {
+	return &MockPeerManager_AddToBlackListByIP_Call{Call: _e.mock.On("AddToBlackListByIP", addr, blockTime, reason)}
 }
 
-func (_c *MockPeerManager_AddToBlackListByAddr_Call) Run(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByAddr_Call {
+func (_c *MockPeerManager_AddToBlackListByIP_Call) Run(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByIP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 proto.TCPAddr
 		if args[0] != nil {
@@ -136,12 +136,12 @@ func (_c *MockPeerManager_AddToBlackListByAddr_Call) Run(run func(addr proto.TCP
 	return _c
 }
 
-func (_c *MockPeerManager_AddToBlackListByAddr_Call) Return() *MockPeerManager_AddToBlackListByAddr_Call {
+func (_c *MockPeerManager_AddToBlackListByIP_Call) Return() *MockPeerManager_AddToBlackListByIP_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockPeerManager_AddToBlackListByAddr_Call) RunAndReturn(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByAddr_Call {
+func (_c *MockPeerManager_AddToBlackListByIP_Call) RunAndReturn(run func(addr proto.TCPAddr, blockTime time.Time, reason string)) *MockPeerManager_AddToBlackListByIP_Call {
 	_c.Run(run)
 	return _c
 }

--- a/pkg/node/peers/peer_manager.go
+++ b/pkg/node/peers/peer_manager.go
@@ -49,7 +49,7 @@ type PeerManager interface {
 	ConnectedCount() int
 	EachConnected(func(peer.Peer, *proto.Score))
 	AddToBlackList(peer peer.Peer, blockTime time.Time, reason string)
-	AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string)
+	AddToBlackListByIP(addr proto.TCPAddr, blockTime time.Time, reason string)
 	BlackList() []storage.BlackListedPeer
 	ClearBlackList() error
 	UpdateScore(p peer.Peer, score *proto.Score) error
@@ -175,12 +175,12 @@ func (a *PeerManagerImpl) EachConnected(f func(peer peer.Peer, score *big.Int)) 
 	)
 }
 
-func (a *PeerManagerImpl) AddToBlackListByAddr(addr proto.TCPAddr, blockTime time.Time, reason string) {
+func (a *PeerManagerImpl) AddToBlackListByIP(addr proto.TCPAddr, blockTime time.Time, reason string) {
 	if a.blackListDuration <= 0 {
 		return
 	}
 	if addr.Empty() {
-		return // no need to add empty address to black list
+		return // no need to add empty address to blacklist
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -898,7 +898,7 @@ func filterToIPV4(ips []net.IP) []net.IP {
 	return ips
 }
 
-func resolveHostToIPsv4(host string) ([]net.IP, error) {
+func ResolveHostToIPsv4(host string) ([]net.IP, error) {
 	if host == "" {
 		host = "0.0.0.0" // set default host to 0.0.0.0
 	}
@@ -938,7 +938,7 @@ func ipsV4PortFromString(addr string) ([]net.IP, uint16, error) {
 	if portNum == 0 {
 		return nil, 0, errors.Errorf("invalid port %q", port)
 	}
-	ips, err := resolveHostToIPsv4(host)
+	ips, err := ResolveHostToIPsv4(host)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed to resolve host")
 	}


### PR DESCRIPTION
Fix for #2119.

This pull request refactors the peer blacklisting logic to improve IP resolution, standardize method naming, and enhance test coverage. The main change is to always resolve and blacklist by IPv4 address (ignoring port), simplifying and unifying how peers are blacklisted. Several method and mock names are updated for clarity and consistency, and tests are expanded to cover more scenarios.

**Peer blacklisting improvements:**

* The blacklisting logic in `App.PeersBlackList` now resolves the provided address (IP or IP:port) to one or more IPv4 addresses and blacklists each resolved IP, ignoring the port. This ensures consistent blacklisting regardless of input format. (`pkg/api/peers.go`, `pkg/proto/proto.go`) [[1]](diffhunk://#diff-893004664d3bd32848133b6efbb63b95fe4adc4e2c3e683f6faf0997604e1948R160-R188) [[2]](diffhunk://#diff-9414ee6fc81d60fc74df47fe91c3f51c820bf236c091908007209a3583b174cdL901-R901) [[3]](diffhunk://#diff-9414ee6fc81d60fc74df47fe91c3f51c820bf236c091908007209a3583b174cdL941-R941)
* The helper function `resolveAddrToIPsV4` is introduced to handle address parsing and resolution. (`pkg/api/peers.go`)

**API and handler updates:**

* The `NodeApi.PeersBlackList` handler now writes a 200 OK response on success and wraps errors with context for better debugging. (`pkg/api/node_api.go`)

**Peer manager interface and implementation:**

* The peer manager method for blacklisting is renamed from `AddToBlackListByAddr` to `AddToBlackListByIP` in the interface and implementation, and all usages are updated accordingly. (`pkg/node/peers/peer_manager.go`) [[1]](diffhunk://#diff-99c6964f4429c19ba7563a4b53bf6f1703cd74e309d4b3c82cb3393b5d194141L52-R52) [[2]](diffhunk://#diff-99c6964f4429c19ba7563a4b53bf6f1703cd74e309d4b3c82cb3393b5d194141L178-R178)

**Testing improvements:**

* Tests for peer blacklisting are updated to use the new method names and logic, and are expanded to cover both IP and IP:port inputs, as well as leading slashes. Mock expectations are updated to match the new method signature. (`pkg/api/node_api_test.go`, `pkg/api/peers_test.go`, `pkg/node/peers/mock_peer_manager.go`) [[1]](diffhunk://#diff-5720f4030b9b019cf2c33095fe9df2c07b4c657787cb3e045819567a21f2e559L268-R268) [[2]](diffhunk://#diff-5720f4030b9b019cf2c33095fe9df2c07b4c657787cb3e045819567a21f2e559L279-R282) [[3]](diffhunk://#diff-5720f4030b9b019cf2c33095fe9df2c07b4c657787cb3e045819567a21f2e559R303-R346) [[4]](diffhunk://#diff-5720f4030b9b019cf2c33095fe9df2c07b4c657787cb3e045819567a21f2e559L317-R360) [[5]](diffhunk://#diff-5720f4030b9b019cf2c33095fe9df2c07b4c657787cb3e045819567a21f2e559R383-R385) [[6]](diffhunk://#diff-a2ebf36fe8af2bfe196e5efa3cf7b86d4b577368e69705df7dd238bdc46fbde4L117-R157) [[7]](diffhunk://#diff-a2ebf36fe8af2bfe196e5efa3cf7b86d4b577368e69705df7dd238bdc46fbde4R178) [[8]](diffhunk://#diff-b5143921ef5a3fa483b3fb3acb53c10327a639ca6eb62838290292252ac415c1L97-R116) [[9]](diffhunk://#diff-b5143921ef5a3fa483b3fb3acb53c10327a639ca6eb62838290292252ac415c1L139-R144)

**Proto utility function:**

* The internal `resolveHostToIPsv4` is made public as `ResolveHostToIPsv4` for use in the new address resolution logic. (`pkg/proto/proto.go`)

These changes collectively make peer blacklisting more robust, consistent, and easier to maintain.