### PR TITLE
Bump codeql deps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,4 +81,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,7 +67,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
           jq empty gosec_fixed.sarif
           mv gosec_fixed.sarif gosec.sarif
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           sarif_file: gosec.sarif
 
@@ -88,7 +88,7 @@ jobs:
               fi
           EOF
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           sarif_file: semgrep.sarif
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `github/codeql-action` for CodeQL analysis and SARIF file uploads. The main goal is to keep the workflows up to date with the latest features, improvements, and security patches provided by the updated action.

**Workflow dependency updates:**

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L59-R59): Updated `github/codeql-action/init`, `github/codeql-action/autobuild`, and `github/codeql-action/analyze` steps to use version `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` instead of the previous version. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L59-R59) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L70-R70) [[3]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L84-R84)
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL53-R53): Updated `github/codeql-action/upload-sarif` steps to use version `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` instead of the previous version for both SARIF upload jobs. [[1]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL53-R53) [[2]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL91-R91)