### PR TITLE
Fix stack overflow by JSON module for 'BlockchainSettings' since go1.27.

### DIFF
--- a/pkg/settings/blockchain_settings.go
+++ b/pkg/settings/blockchain_settings.go
@@ -185,8 +185,8 @@ type BlockchainSettings struct {
 }
 
 func (s *BlockchainSettings) UnmarshalJSON(bytes []byte) error {
-	type shadowed *BlockchainSettings
-	if err := json.Unmarshal(bytes, shadowed(s)); err != nil {
+	type shadowed BlockchainSettings
+	if err := json.Unmarshal(bytes, (*shadowed)(s)); err != nil {
 		return err
 	}
 	return s.validate()


### PR DESCRIPTION
This pull request updates the `UnmarshalJSON` method of the `BlockchainSettings` struct to fix a bug with how the type alias is used during JSON unmarshalling. This change ensures the method works correctly by using a non-pointer type alias and casting the receiver appropriately.

Bug fix:

* Updated the `UnmarshalJSON` method in `blockchain_settings.go` to use a non-pointer type alias (`shadowed BlockchainSettings`) and cast the receiver to `*shadowed`, resolving issues with JSON unmarshalling.