### PR TITLE
Update to go 1.26.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
 

--- a/.github/workflows/deploy_node.yml
+++ b/.github/workflows/deploy_node.yml
@@ -84,10 +84,10 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: false # don't save & restore build caches because golangci-lint action does it internally
 
@@ -65,10 +65,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
 

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: false
 

--- a/.github/workflows/run_itests.yml
+++ b/.github/workflows/run_itests.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
         id: go

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
         # To fix those issues the first part of jq query copies content of `markdown` field into `text` field
         # if it's not present. In the second part if the `fixes` object has null array as `artifactChanges` the empty
         # valid `artifactChange` object inserted.
-        # After fix of mentioned gosec issues this step can be removed. 
+        # After fix of mentioned gosec issues this step can be removed.
         run: |
           set -e
           jq 'walk(if type=="object" and has("markdown") and (.text == null or .text == "") then .text = .markdown else . end) | (.runs[].results[]? .fixes[]? .artifactChanges) |= (if . == null then [{"artifactLocation": { "uri": "" }, "replacements": [{"deletedRegion": {"byteOffset": 0, "byteLength": 0 }}]}] else . end)' gosec.sarif > gosec_fixed.sarif
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
       - name: Run go list

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Send the transaction to the network:
 
 ### Building from sources
 
-Go version 1.25 or later is required to build the `node`, `importer`, `wallet` and other tools.
+Go version 1.26 or later is required to build the `node`, `importer`, `wallet` and other tools.
 
 To build a node, importer or other tools run a `make` command:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wavesplatform/gowaves
 
-go 1.25.7
+go 1.26.0
 
 require (
 	filippo.io/edwards25519 v1.2.0


### PR DESCRIPTION
This pull request updates the Go version used across the codebase and CI workflows from 1.25 to 1.26. This ensures the project uses the latest Go features, improvements, and security updates. The change is reflected in the build configuration, documentation, and all relevant GitHub Actions workflows.

**Go version upgrade:**

* Updated the Go version in `go.mod` to `1.26.0`.
* Updated all GitHub Actions workflows (`.github/workflows/go.yml`, `codeql-analysis.yml`, `deploy_node.yml`, `publish-to-ghcr.yml`, `run_itests.yml`, `security.yml`) to use Go 1.26 instead of 1.25. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL35-R38) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL68-R71) [[3]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L50-R53) [[4]](diffhunk://#diff-2883c238d190b138336f04e76e058f7057ada327c04063fa207f802a1f0e577aL87-R90) [[5]](diffhunk://#diff-cd1c8dcae4456d5ffcf205b278a47c656645b94c05b0f4200032df2ffc58b26dL35-R38) [[6]](diffhunk://#diff-dc8910056c677f0c85a7f2dc7d8cbfed81ea7b249f70255aaced6ae56252ecbaL51-R54) [[7]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL106-R106)

**Documentation:**

* Updated the Go version requirement in `README.md` to specify Go 1.26 or later.